### PR TITLE
container-logs-panel: Use a monospaced font

### DIFF
--- a/data/resources/ui/container-logs-panel.ui
+++ b/data/resources/ui/container-logs-panel.ui
@@ -43,12 +43,14 @@
             <property name="vexpand">True</property>
 
             <child>
-              <object class="GtkTextView" id="text_view">
+              <object class="GtkTextView">
                 <property name="buffer">
                   <object class="GtkTextBuffer" id="text_buffer"/>
                 </property>
                 <property name="editable">False</property>
                 <property name="wrap-mode">char</property>
+                <property name="monospace">True</property>
+                <property name="cursor-visible">False</property>
               </object>
             </child>
 

--- a/data/resources/ui/container-logs-panel.ui
+++ b/data/resources/ui/container-logs-panel.ui
@@ -43,7 +43,7 @@
             <property name="vexpand">True</property>
 
             <child>
-              <object class="GtkTextView">
+              <object class="GtkTextView" id="text_view">
                 <property name="buffer">
                   <object class="GtkTextBuffer" id="text_buffer"/>
                 </property>

--- a/src/view/container/container_logs_panel.rs
+++ b/src/view/container/container_logs_panel.rs
@@ -28,8 +28,6 @@ mod imp {
         pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
         pub(super) text_buffer: TemplateChild<gtk::TextBuffer>,
-        #[template_child]
-        pub(super) text_view: TemplateChild<gtk::TextView>,
     }
 
     #[glib::object_subclass]
@@ -98,8 +96,7 @@ mod imp {
 
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
-            self.text_view.set_property("monospace", true);
-            self.text_view.set_property("cursor-visible", false);
+
             let adj = self.scrolled_window.vadjustment();
             adj.connect_value_changed(clone!(@weak obj => move |adj| {
                 let self_ = Self::from_instance(&obj);

--- a/src/view/container/container_logs_panel.rs
+++ b/src/view/container/container_logs_panel.rs
@@ -28,6 +28,8 @@ mod imp {
         pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
         pub(super) text_buffer: TemplateChild<gtk::TextBuffer>,
+        #[template_child]
+        pub(super) text_view: TemplateChild<gtk::TextView>,
     }
 
     #[glib::object_subclass]
@@ -96,7 +98,8 @@ mod imp {
 
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
-
+            self.text_view.set_property("monospace", true);
+            self.text_view.set_property("cursor-visible", false);
             let adj = self.scrolled_window.vadjustment();
             adj.connect_value_changed(clone!(@weak obj => move |adj| {
                 let self_ = Self::from_instance(&obj);


### PR DESCRIPTION
Also hides the cursor, since the TextView is not for input.

Please let me know if that's not the right place or method to set those properties, I'm very new to rust and GTK.