### PR TITLE
clippy: Allow `format_push_string`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::format_push_string)]
+
 mod api;
 mod application;
 #[rustfmt::skip]


### PR DESCRIPTION
This warning originates in the gettext macro. So there's nothing we can
do to prevent it.