### PR TITLE
Fix(style): Set initial bg and fg color

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -134,6 +134,8 @@ impl Application {
         if let Some(display) = gdk::Display::default() {
             gtk::StyleContext::add_provider_for_display(&display, &imp.provider, 400);
         }
+
+        self.set_headerbar_background(None);
     }
 
     pub(crate) fn set_headerbar_background(&self, bg_color: Option<gdk::RGBA>) {


### PR DESCRIPTION
Otherwise, the headerbar text is hardly readable when starting the
application the for the first time.