### PR TITLE
ci: Disable aarch64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       options: --privileged
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        arch: [x86_64]
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     needs: [rustfmt, clippy]


### PR DESCRIPTION
Lately it fails. Probably because it exceeds the memory limit.