### PR TITLE
fix(container-creation-page): Make memory limit work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 [[package]]
 name = "podman-api"
 version = "0.4.0"
-source = "git+https://github.com/marhkb/podman-api-rs.git?branch=staging#a02f80d9c5a2a12feea8b1a7a3fba5d563c6624f"
+source = "git+https://github.com/marhkb/podman-api-rs.git?branch=staging#990a1162a0c04440c531cc58d48e92e4a5727be5"
 dependencies = [
  "base64",
  "byteorder",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "podman-api-stubs"
 version = "0.5.0"
-source = "git+https://github.com/marhkb/podman-api-rs.git?branch=staging#a02f80d9c5a2a12feea8b1a7a3fba5d563c6624f"
+source = "git+https://github.com/marhkb/podman-api-rs.git?branch=staging#990a1162a0c04440c531cc58d48e92e4a5727be5"
 dependencies = [
  "chrono",
  "serde",

--- a/src/view/container/container_creation_page.rs
+++ b/src/view/container/container_creation_page.rs
@@ -701,44 +701,25 @@ impl ContainerCreationPage {
 
         let create_opts = if imp.memory_switch.is_active() {
             create_opts.resource_limits(podman::models::LinuxResources {
-                block_io: podman::models::LinuxBlockIo {
-                    leaf_weight: None,
-                    throttle_read_bps_device: None,
-                    throttle_read_iops_device: None,
-                    throttle_write_bps_device: None,
-                    throttle_write_iops_device: None,
-                    weight: None,
-                    weight_device: None,
-                },
-                cpu: podman::models::LinuxCpu {
-                    cpus: None,
-                    mems: None,
-                    period: None,
-                    quota: None,
-                    realtime_period: None,
-                    realtime_runtime: None,
-                    shares: None,
-                },
+                block_io: None,
+                cpu: None,
                 devices: None,
                 hugepage_limits: None,
-                memory: podman::models::LinuxMemory {
+                memory: Some(podman::models::LinuxMemory {
                     disable_oom_killer: None,
                     kernel: None,
                     kernel_tcp: None,
                     limit: Some(
                         imp.mem_value.value() as i64
-                            * 1024_i64.pow(imp.mem_combo_box.active().map(|i| i + 1).unwrap_or(0)),
+                            * 1000_i64.pow(imp.mem_combo_box.active().map(|i| i + 1).unwrap_or(0)),
                     ),
                     reservation: None,
                     swap: None,
                     swappiness: None,
                     use_hierarchy: None,
-                },
-                network: podman::models::LinuxNetwork {
-                    class_id: None,
-                    priorities: None,
-                },
-                pids: podman::models::LinuxPids { limit: None },
+                }),
+                network: None,
+                pids: None,
                 rdma: None,
                 unified: None,
             })


### PR DESCRIPTION
The new models in `posman-api-rs` have made most of the fields in
`LinuxResources` mandatory. This leads to errors if only individual
limits are to be set selectively. Podman then tries to set the other
limits as well. This in turn can lead to errors when starting
containers.

All fields are therefore made optional again.

Furthermore, the megabytes are now correctly converted to bytes.