### PR TITLE
fix(container): Re-add `Stopped` and `Stopping` states

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -67,6 +67,8 @@ connectionchooserpage connectionswitchermenu row {
 
 .container-status-created,
 .container-status-exited,
+.container-status-stopped,
+.container-status-stopping,
 .pod-status-created,
 .pod-status-exited,
 .pod-status-stopped,

--- a/src/model/container.rs
+++ b/src/model/container.rs
@@ -31,6 +31,8 @@ pub(crate) enum Status {
     Paused,
     Restarting,
     Running,
+    Stopped,
+    Stopping,
     #[default]
     Unknown,
 }
@@ -46,6 +48,8 @@ impl FromStr for Status {
             "paused" => Self::Paused,
             "restarting" => Self::Restarting,
             "running" => Self::Running,
+            "stopped" => Self::Stopped,
+            "stopping" => Self::Stopping,
             _ => return Err(Self::Unknown),
         })
     }
@@ -63,6 +67,8 @@ impl fmt::Display for Status {
                 Self::Paused => gettext("Paused"),
                 Self::Restarting => gettext("Restarting"),
                 Self::Running => gettext("Running"),
+                Self::Stopped => gettext("Stopped"),
+                Self::Stopping => gettext("Stopping"),
                 Self::Unknown => gettext("Unknown"),
             }
         )

--- a/src/view/container/mod.rs
+++ b/src/view/container/mod.rs
@@ -39,6 +39,8 @@ fn container_status_css_class(status: model::ContainerStatus) -> &'static str {
         Paused => "container-status-paused",
         Restarting => "container-status-restarting",
         Running => "container-status-running",
+        Stopped => "container-status-stopped",
+        Stopping => "container-status-stopping",
         Unknown => "container-status-unknown",
     }
 }


### PR DESCRIPTION
These were removed at some point by accident.