### PR TITLE
fix(pod-list): Notify `running` if status has changed

### DIFF
--- a/src/model/pod_list.rs
+++ b/src/model/pod_list.rs
@@ -259,6 +259,10 @@ impl PodList {
     }
 
     fn pod_added(&self, pod: &model::Pod) {
+        pod.connect_notify_local(
+            Some("status"),
+            clone!(@weak self as obj => move |_, _| obj.notify("running")),
+        );
         self.emit_by_name::<()>("pod-added", &[pod]);
     }
 


### PR DESCRIPTION
Otherwise, the number of running pods won't update in the UI.