### PR TITLE
doc: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!-- Your issue may already be reported!
+Please search on the issue tracker before creating one. -->
+
+### Reproduction steps
+
+### Environment
+
+- Pods version: <!--  run 'pods version' if using a release, 'git describe' if building from master -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+<!-- Your feature may already be reported!
+Please search on the issue tracker before creating one. -->
+
+#### Describe your feature request
+


### PR DESCRIPTION
This PR adds GitHub Issue Templates that allow easier creation of issues by category. There are three options:
 * Blank issue
 * Bug report
 * Feature request
 
 They have some basic boilerplate and set an appropriate label when the issue is created making it easier to sort through the issues without manually going through them.