### PR TITLE
feat(inspection-page): Load inspection data during construction

### DIFF
--- a/data/resources/ui/component/inspection-page.ui
+++ b/data/resources/ui/component/inspection-page.ui
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-
   <template class="PdsInspectionPage" parent="GtkWidget">
     <property name="layout-manager">
       <object class="GtkBoxLayout">
@@ -41,29 +40,52 @@
     </child>
 
     <child>
-      <object class="GtkScrolledWindow" id="scrolled_window">
-        <property name="hscrollbar-policy">never</property>
-        <property name="vexpand">True</property>
+      <object class="GtkStack" id="stack">
 
         <child>
-          <object class="GtkSourceView" id="source_view">
-            <style>
-              <class name="text-view"/>
-            </style>
-            <property name="buffer">
-              <object class="GtkSourceBuffer" id="source_buffer">
-                <property name="highlight-matching-brackets">False</property>
+          <object class="GtkSpinner" id="spinner">
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="height-request">24</property>
+            <property name="width-request">24</property>
+            <property name="spinning">True</property>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">loaded</property>
+
+            <property name="child">
+              <object class="GtkScrolledWindow">
+                <property name="hscrollbar-policy">never</property>
+                <property name="vexpand">True</property>
+
+                <child>
+                  <object class="GtkSourceView" id="source_view">
+                    <style>
+                      <class name="text-view"/>
+                    </style>
+                    <property name="buffer">
+                      <object class="GtkSourceBuffer" id="source_buffer">
+                        <property name="highlight-matching-brackets">False</property>
+                      </object>
+                    </property>
+                    <property name="top-margin">12</property>
+                    <property name="bottom-margin">12</property>
+                    <property name="right-margin">12</property>
+                    <property name="cursor-visible">False</property>
+                    <property name="editable">False</property>
+                    <property name="highlight-current-line">True</property>
+                    <property name="monospace">True</property>
+                    <property name="show-line-numbers">True</property>
+                    <property name="wrap-mode">char</property>
+                  </object>
+                </child>
+
               </object>
             </property>
-            <property name="top-margin">12</property>
-            <property name="bottom-margin">12</property>
-            <property name="right-margin">12</property>
-            <property name="cursor-visible">False</property>
-            <property name="editable">False</property>
-            <property name="highlight-current-line">True</property>
-            <property name="monospace">True</property>
-            <property name="show-line-numbers">True</property>
-            <property name="wrap-mode">char</property>
+
           </object>
         </child>
 
@@ -71,5 +93,4 @@
     </child>
 
   </template>
-
 </interface>

--- a/data/resources/ui/container/details-page.ui
+++ b/data/resources/ui/container/details-page.ui
@@ -59,19 +59,12 @@
                     <property name="title" translatable="yes">Utilities</property>
 
                     <child>
-                      <object class="AdwActionRow" id="inspect_row">
+                      <object class="AdwActionRow">
                         <property name="title" translatable="yes">Inspect</property>
                         <property name="subtitle" translatable="yes">View all container properties in a structured text form.</property>
                         <property name="activatable">True</property>
                         <property name="action-name">container-details-page.inspect</property>
                         <property name="icon-name">system-search-symbolic</property>
-
-                        <child>
-                          <object class="GtkSpinner">
-                            <property name="spinning">True</property>
-                            <property name="visible" bind-source="inspect_row" bind-property="sensitive" bind-flags="sync-create|invert-boolean"/>
-                          </object>
-                        </child>
 
                         <child>
                           <object class="GtkImage">

--- a/data/resources/ui/image/details-page.ui
+++ b/data/resources/ui/image/details-page.ui
@@ -121,19 +121,12 @@
                     <property name="title" translatable="yes">Utilities</property>
 
                     <child>
-                      <object class="AdwActionRow" id="inspect_row">
+                      <object class="AdwActionRow">
                         <property name="title" translatable="yes">Inspect</property>
                         <property name="subtitle" translatable="yes">View all image properties in a structured text form.</property>
                         <property name="activatable">True</property>
                         <property name="action-name">image-details-page.inspect-image</property>
                         <property name="icon-name">system-search-symbolic</property>
-
-                        <child>
-                          <object class="GtkSpinner">
-                            <property name="spinning">True</property>
-                            <property name="visible" bind-source="inspect_row" bind-property="sensitive" bind-flags="sync-create|invert-boolean"/>
-                          </object>
-                        </child>
 
                         <child>
                           <object class="GtkImage">

--- a/data/resources/ui/pod/details-page.ui
+++ b/data/resources/ui/pod/details-page.ui
@@ -125,19 +125,12 @@
                     <property name="title" translatable="yes">Utilities</property>
 
                     <child>
-                      <object class="AdwActionRow" id="inspect_row">
+                      <object class="AdwActionRow">
                         <property name="title" translatable="yes">Inspect</property>
                         <property name="subtitle" translatable="yes">View all pod properties in a structured text form.</property>
                         <property name="activatable">True</property>
                         <property name="action-name">pod-details-page.inspect-pod</property>
                         <property name="icon-name">system-search-symbolic</property>
-
-                        <child>
-                          <object class="GtkSpinner">
-                            <property name="spinning">True</property>
-                            <property name="visible" bind-source="inspect_row" bind-property="sensitive" bind-flags="sync-create|invert-boolean"/>
-                          </object>
-                        </child>
 
                         <child>
                           <object class="GtkImage">

--- a/src/view/component/mod.rs
+++ b/src/view/component/mod.rs
@@ -13,6 +13,7 @@ mod top_page;
 pub(crate) use back_navigation_controls::BackNavigationControls;
 pub(crate) use circular_progress_bar::CircularProgressBar;
 pub(crate) use count_badge::CountBadge;
+pub(crate) use inspection_page::Inspectable;
 pub(crate) use inspection_page::InspectionPage;
 pub(crate) use leaflet_overlay::LeafletOverlay;
 pub(crate) use property_row::PropertyRow;

--- a/src/view/container/details_page.rs
+++ b/src/view/container/details_page.rs
@@ -200,25 +200,11 @@ impl DetailsPage {
             .as_ref()
             .and_then(model::Container::api_container)
         {
-            self.action_set_enabled(ACTION_INSPECT, false);
-            utils::do_async(
-                async move { container.inspect().await.map_err(anyhow::Error::from) },
-                clone!(@weak self as obj => move |result| {
-                    obj.action_set_enabled(ACTION_INSPECT, true);
-                    match result
-                        .and_then(|data| view::InspectionPage::new(
-                            &gettext("Container Inspection"), &data
-                        ))
-                    {
-                        Ok(page) =>  obj.imp().leaflet_overlay.show_details(&page),
-                        Err(e) => utils::show_error_toast(
-                            &obj,
-                            &gettext("Error on inspecting container"),
-                            &e.to_string()
-                        ),
-                    }
-                }),
-            );
+            self.imp()
+                .leaflet_overlay
+                .show_details(&view::InspectionPage::from(view::Inspectable::Container(
+                    container,
+                )));
         }
     }
 

--- a/src/view/image/details_page.rs
+++ b/src/view/image/details_page.rs
@@ -316,25 +316,9 @@ impl DetailsPage {
 
     fn show_inspection(&self) {
         if let Some(image) = self.image().as_ref().and_then(model::Image::api_image) {
-            self.action_set_enabled(ACTION_INSPECT_IMAGE, false);
-            utils::do_async(
-                async move { image.inspect().await.map_err(anyhow::Error::from) },
-                clone!(@weak self as obj => move |result| {
-                    obj.action_set_enabled(ACTION_INSPECT_IMAGE, true);
-                    match result
-                        .and_then(|data| view::InspectionPage::new(
-                            &gettext("Image Inspection"), &data
-                        ))
-                    {
-                        Ok(page) => obj.imp().leaflet_overlay.show_details(&page),
-                        Err(e) => utils::show_error_toast(
-                            &obj,
-                            &gettext("Error on inspecting image"),
-                            &e.to_string()
-                        ),
-                    }
-                }),
-            );
+            self.imp()
+                .leaflet_overlay
+                .show_details(&view::InspectionPage::from(view::Inspectable::Image(image)));
         }
     }
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -26,6 +26,7 @@ pub(crate) use cmd_arg::Row as CmdArgRow;
 pub(crate) use component::BackNavigationControls;
 pub(crate) use component::CircularProgressBar;
 pub(crate) use component::CountBadge;
+pub(crate) use component::Inspectable;
 pub(crate) use component::InspectionPage;
 pub(crate) use component::LeafletOverlay;
 pub(crate) use component::PropertyRow;

--- a/src/view/pod/details_page.rs
+++ b/src/view/pod/details_page.rs
@@ -235,25 +235,9 @@ impl DetailsPage {
 
     fn show_inspection(&self) {
         if let Some(pod) = self.pod().as_ref().and_then(model::Pod::api_pod) {
-            self.action_set_enabled(ACTION_INSPECT_POD, false);
-            utils::do_async(
-                async move { pod.inspect().await.map_err(anyhow::Error::from) },
-                clone!(@weak self as obj => move |result| {
-                    obj.action_set_enabled(ACTION_INSPECT_POD, true);
-                    match result
-                        .and_then(|data| view::InspectionPage::new(
-                            &gettext("Pod Inspection"), &data
-                        ))
-                    {
-                        Ok(page) => obj.imp().leaflet_overlay.show_details(&page),
-                        Err(e) => utils::show_error_toast(
-                            &obj,
-                            &gettext("Error on inspecting pod"),
-                            &e.to_string()
-                        ),
-                    }
-                }),
-            );
+            self.imp()
+                .leaflet_overlay
+                .show_details(&view::InspectionPage::from(view::Inspectable::Pod(pod)));
         }
     }
 


### PR DESCRIPTION
Previously, the inspection data was loaded on the corresponding detail page after pressing the button and then passed to the inspection page. But this could lead to short delays.

Therefore, in this commit, the loading of the inspection data is moved to the inspection page. This way it is possible to switch to it immediately. Until the data is loaded, a spinner is displayed.