### PR TITLE
fix(back-navigation-controls): Update the icon

### DIFF
--- a/data/resources/ui/component/back-navigation-controls.ui
+++ b/data/resources/ui/component/back-navigation-controls.ui
@@ -17,7 +17,7 @@
 
     <child>
       <object class="GtkButton" id="go_first_button">
-        <property name="icon-name">go-first-symbolic</property>
+        <property name="icon-name">user-home-symbolic</property>
         <property name="action-name">back-navigation-controls.go-first</property>
         <property name="tooltip-text" translatable="yes">Return to main page</property>
         <property name="visible" bind-source="go_first_button" bind-property="sensitive" bind-flags="sync-create"/>


### PR DESCRIPTION
This PR updates the icon used by `back-navigation-controls` to `user-home-symbolic` as the previous icon was confusing.

New view:
![image](https://user-images.githubusercontent.com/46892771/194830071-d598588c-0dcd-4e94-8176-25b2a18c731e.png)
![image](https://user-images.githubusercontent.com/46892771/194830119-1a1fd32c-2020-4ff0-8e14-7dd98f24987f.png)


Closes: #369