### PR TITLE
fix(pod-creation-page): Make the hosts switch enabled by default

### DIFF
--- a/data/resources/ui/pod/creation-page.ui
+++ b/data/resources/ui/pod/creation-page.ui
@@ -191,6 +191,7 @@
                                           <object class="GtkSwitch" id="enable_hosts_switch">
                                             <property name="valign">center</property>
                                             <property name="action-name">pod.toggle-hosts</property>
+                                            <property name="active">true</property>
                                           </object>
                                         </child>
 


### PR DESCRIPTION
This PR makes the hosts switch enabled by default. This is preferred behavior as having the switch disabled adds the `no_manage_hosts` flag that completely disables `/etc/hosts` management and it might prevent basic network communication between containers in the pod and we want defaults to just work.