### PR TITLE
Refactor/port-to-gtk-dropdown

### DIFF
--- a/data/resources/ui/container/creation-page.ui
+++ b/data/resources/ui/container/creation-page.ui
@@ -236,13 +236,17 @@
                                                     </child>
 
                                                     <child>
-                                                      <object class="GtkComboBoxText" id="mem_combo_box">
-                                                        <items>
-                                                          <item translatable="yes">KB</item>
-                                                          <item translatable="yes">MB</item>
-                                                          <item translatable="yes">GB</item>
-                                                        </items>
-                                                        <property name="active">1</property>
+                                                      <object class="GtkDropDown" id="mem_drop_down">
+                                                        <property name="model">
+                                                          <object class="GtkStringList">
+                                                            <items>
+                                                              <item translatable="yes">KB</item>
+                                                              <item translatable="yes">MB</item>
+                                                              <item translatable="yes">GB</item>
+                                                            </items>
+                                                          </object>
+                                                        </property>
+                                                        <property name="selected">1</property>
                                                         <property name="valign">center</property>
                                                       </object>
                                                     </child>

--- a/data/resources/ui/images/prune-page.ui
+++ b/data/resources/ui/images/prune-page.ui
@@ -145,12 +145,16 @@
                                     </child>
 
                                     <child>
-                                      <object class="GtkComboBoxText" id="period_combo_box">
+                                      <object class="GtkDropDown" id="period_drop_down">
                                         <property name="valign">center</property>
-                                        <items>
-                                          <item translatable="yes">AM</item>
-                                          <item translatable="yes">PM</item>
-                                        </items>
+                                        <property name="model">
+                                          <object class="GtkStringList">
+                                            <items>
+                                              <item translatable="yes">AM</item>
+                                              <item translatable="yes">PM</item>
+                                            </items>
+                                          </object>
+                                        </property>
                                       </object>
                                     </child>
 

--- a/data/resources/ui/port-mapping/row.ui
+++ b/data/resources/ui/port-mapping/row.ui
@@ -56,12 +56,15 @@
             <property name="spacing">9</property>
 
             <child>
-              <object class="GtkComboBoxText" id="protocol_combo_box">
-                <items>
-                  <item translatable="yes">TCP</item>
-                  <item translatable="yes">UDP</item>
-                </items>
-                <property name="active">0</property>
+              <object class="GtkDropDown" id="protocol_drop_down">
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">TCP</item>
+                      <item translatable="yes">UDP</item>
+                    </items>
+                  </object>
+                </property>
               </object>
             </child>
 

--- a/data/resources/ui/volume/row.ui
+++ b/data/resources/ui/volume/row.ui
@@ -73,13 +73,16 @@
                 </child>
 
                 <child>
-                  <object class="GtkComboBoxText" id="selinux_combo_box">
-                    <items>
-                      <item translatable="yes">No label</item>
-                      <item translatable="yes">Shared</item>
-                      <item translatable="yes">Private</item>
-                    </items>
-                    <property name="active">0</property>
+                  <object class="GtkDropDown" id="selinux_drop_down">
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">No label</item>
+                          <item translatable="yes">Shared</item>
+                          <item translatable="yes">Private</item>
+                        </items>
+                      </object>
+                    </property>
                     <property name="hexpand">True</property>
                   </object>
                 </child>

--- a/src/view/container/creation_page.rs
+++ b/src/view/container/creation_page.rs
@@ -77,7 +77,7 @@ mod imp {
         #[template_child]
         pub(super) mem_value: TemplateChild<gtk::Adjustment>,
         #[template_child]
-        pub(super) mem_combo_box: TemplateChild<gtk::ComboBoxText>,
+        pub(super) mem_drop_down: TemplateChild<gtk::DropDown>,
         #[template_child]
         pub(super) port_mapping_list_box: TemplateChild<gtk::ListBox>,
         #[template_child]
@@ -801,7 +801,7 @@ impl CreationPage {
                     kernel_tcp: None,
                     limit: Some(
                         imp.mem_value.value() as i64
-                            * 1000_i64.pow(imp.mem_combo_box.active().map(|i| i + 1).unwrap_or(0)),
+                            * 1000_i64.pow(imp.mem_drop_down.selected() + 1),
                     ),
                     reservation: None,
                     swap: None,

--- a/src/view/images/prune_page.rs
+++ b/src/view/images/prune_page.rs
@@ -52,7 +52,7 @@ mod imp {
         #[template_child]
         pub(super) minute_spin_button: TemplateChild<gtk::SpinButton>,
         #[template_child]
-        pub(super) period_combo_box: TemplateChild<gtk::ComboBoxText>,
+        pub(super) period_drop_down: TemplateChild<gtk::DropDown>,
         #[template_child]
         pub(super) button_prune: TemplateChild<gtk::Button>,
         #[template_child]
@@ -146,7 +146,7 @@ mod imp {
                     self.calendar.property_expression("day"),
                     self.hour_spin_button.property_expression("value"),
                     self.minute_spin_button.property_expression("value"),
-                    self.period_combo_box.property_expression("active"),
+                    self.period_drop_down.property_expression("selected"),
                 ],
                 closure!(|obj: Self::Type,
                           year: i32,
@@ -154,7 +154,7 @@ mod imp {
                           day: i32,
                           hour: f64,
                           minute: f64,
-                          period: i32| {
+                          period: u32| {
                     glib::DateTime::from_local(
                         year,
                         month + 1,
@@ -206,8 +206,8 @@ mod imp {
 
             self.hour_spin_button.set_value(hour as f64);
             self.minute_spin_button.set_value(minute as f64);
-            self.period_combo_box
-                .set_active(Some(if hour < 12 { 0 } else { 1 }));
+            self.period_drop_down
+                .set_selected(if hour < 12 { 0 } else { 1 });
         }
 
         fn dispose(&self, obj: &Self::Type) {
@@ -257,7 +257,7 @@ impl PrunePage {
         match imp.desktop_settings.get::<String>("clock-format").as_str() {
             "12h" => {
                 imp.hour_adjustment.set_upper(11.0);
-                imp.period_combo_box.set_visible(true);
+                imp.period_drop_down.set_visible(true);
                 imp.time_format.set(TimeFormat::Hours12);
             }
             other => {
@@ -265,7 +265,7 @@ impl PrunePage {
                     log::warn!("Unknown time format '{other}'. Falling back to '24h'.");
                 }
                 imp.hour_adjustment.set_upper(23.0);
-                imp.period_combo_box.set_visible(false);
+                imp.period_drop_down.set_visible(false);
                 imp.time_format.set(TimeFormat::Hours24);
             }
         }

--- a/src/view/port_mapping/row.rs
+++ b/src/view/port_mapping/row.rs
@@ -19,7 +19,7 @@ mod imp {
         #[template_child]
         pub(super) container_port_adjustment: TemplateChild<gtk::Adjustment>,
         #[template_child]
-        pub(super) protocol_combo_box: TemplateChild<gtk::ComboBoxText>,
+        pub(super) protocol_drop_down: TemplateChild<gtk::DropDown>,
         #[template_child]
         pub(super) ip_address_entry: TemplateChild<gtk::Entry>,
         #[template_child]
@@ -125,20 +125,20 @@ impl Row {
             bindings.push(binding);
 
             let binding = port_mapping
-                .bind_property("protocol", &*imp.protocol_combo_box, "active")
+                .bind_property("protocol", &*imp.protocol_drop_down, "selected")
                 .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
                 .transform_to(|_, value| {
                     Some(
                         match value.get::<model::PortMappingProtocol>().unwrap() {
-                            model::PortMappingProtocol::Tcp => 0,
-                            model::PortMappingProtocol::Udp => 1,
+                            model::PortMappingProtocol::Tcp => 0_u32,
+                            model::PortMappingProtocol::Udp => 1_u32,
                         }
                         .to_value(),
                     )
                 })
                 .transform_from(|_, value| {
                     Some(
-                        if value.get::<i32>().unwrap() == 0 {
+                        if value.get::<u32>().unwrap() == 0 {
                             model::PortMappingProtocol::Tcp
                         } else {
                             model::PortMappingProtocol::Udp

--- a/src/view/volume/row.rs
+++ b/src/view/volume/row.rs
@@ -19,7 +19,7 @@ mod imp {
         #[template_child]
         pub(super) writable_switch: TemplateChild<gtk::Switch>,
         #[template_child]
-        pub(super) selinux_combo_box: TemplateChild<gtk::ComboBoxText>,
+        pub(super) selinux_drop_down: TemplateChild<gtk::DropDown>,
         #[template_child]
         pub(super) host_path_entry: TemplateChild<gtk::Entry>,
         #[template_child]
@@ -124,21 +124,21 @@ impl Row {
             bindings.push(binding);
 
             let binding = volume
-                .bind_property("selinux", &*imp.selinux_combo_box, "active")
+                .bind_property("selinux", &*imp.selinux_drop_down, "selected")
                 .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
                 .transform_to(|_, value| {
                     Some(
                         match value.get::<model::VolumeSELinux>().unwrap() {
-                            model::VolumeSELinux::NoLabel => 0,
-                            model::VolumeSELinux::Shared => 1,
-                            model::VolumeSELinux::Private => 2,
+                            model::VolumeSELinux::NoLabel => 0_u32,
+                            model::VolumeSELinux::Shared => 1_u32,
+                            model::VolumeSELinux::Private => 2_u32,
                         }
                         .to_value(),
                     )
                 })
                 .transform_from(|_, value| {
                     Some(
-                        match value.get::<i32>().unwrap() {
+                        match value.get::<u32>().unwrap() {
                             0 => model::VolumeSELinux::NoLabel,
                             1 => model::VolumeSELinux::Shared,
                             _ => model::VolumeSELinux::Private,


### PR DESCRIPTION
The porting has to be done because `GtkComboBoxText` is deprecated.