### PR TITLE
style(container-creation-page): Simplify pod combo row

### DIFF
--- a/data/resources/ui/container/creation-page.ui
+++ b/data/resources/ui/container/creation-page.ui
@@ -151,20 +151,8 @@
                                     </child>
 
                                     <child>
-                                      <object class="AdwExpanderRow" id="pod_expander_row">
-                                        <property name="enable-expansion" bind-source="pod_switch" bind-property="active" bind-flags="sync-create"/>
+                                      <object class="AdwComboRow" id="pod_combo_row">
                                         <property name="title" translatable="yes">Pod</property>
-
-                                        <child type="action">
-                                          <object class="GtkSwitch" id="pod_switch">
-                                            <property name="valign">center</property>
-                                          </object>
-                                        </child>
-
-                                        <child>
-                                          <object class="AdwComboRow" id="pod_combo_row"/>
-                                        </child>
-
                                       </object>
                                     </child>
 


### PR DESCRIPTION
This commit makes the pod combo row more straight forward: First, It can
now be disabled by an entry in the list view popup making the expander
row obsolete. Secondly, pods are now ordered by their names making it
easier to find a pod.