### PR TITLE
refactor(circular-progress-bar): Use snaphot for drawing

### DIFF
--- a/data/resources/ui/component/circular-progress-bar.ui
+++ b/data/resources/ui/component/circular-progress-bar.ui
@@ -5,22 +5,14 @@
     <property name="layout-manager">
       <object class="GtkBinLayout"/>
     </property>
+    <property name="valign">center</property>
+    <property name="width-request">36</property>
+    <property name="height-request">36</property>
 
     <child>
-      <object class="GtkOverlay" id="overlay">
-
-        <child type="overlay">
-          <object class="GtkImage" id="icon">
-            <property name="icon-name">computer-chip-symbolic</property>
-            <property name="valign">center</property>
-            <property name="halign">center</property>
-          </object>
-        </child>
-
-        <child>
-          <object class="GtkDrawingArea" id="drawing_area"/>
-        </child>
-
+      <object class="GtkImage" id="icon">
+        <property name="valign">center</property>
+        <property name="halign">center</property>
       </object>
     </child>
 


### PR DESCRIPTION
This commit removes the drawing area and draws the widget in the proper way by using a `GtkSnapshot`. In this turn, the style of the widget was slightly modified.