### PR TITLE
fix(image): Apply updates

### DIFF
--- a/src/view/search_panel.rs
+++ b/src/view/search_panel.rs
@@ -148,7 +148,7 @@ mod imp {
                     } else if image2.repo_tags().n_items() == 0 {
                         gtk::Ordering::Smaller
                     } else {
-                        image1.repo_tags().cmp(image2.repo_tags()).into()
+                        image1.repo_tags().cmp(&image2.repo_tags()).into()
                     }
                 } else if let Some(container1) = obj1.downcast_ref::<model::Container>() {
                     let container2 = obj2.downcast_ref::<model::Container>().unwrap();


### PR DESCRIPTION
Images need updates. i.e. when the latest image is pulled the old image will become an intermediate. In addition, the properties of `Image` have been stripped down to only those that are actually used.