### PR TITLE
style(container-rename-dialog): Use `AdwMessageDialog` as base

### DIFF
--- a/data/resources/ui/container/rename-dialog.ui
+++ b/data/resources/ui/container/rename-dialog.ui
@@ -1,42 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="PdsContainerRenameDialog" parent="AdwWindow">
-    <property name="default-widget">button_rename</property>
-    <property name="deletable">False</property>
-    <property name="modal">True</property>
-    <property name="resizable">False</property>
-    <property name="width-request">400</property>
+  <template class="PdsContainerRenameDialog" parent="AdwMessageDialog">
+    <property name="default-response">rename</property>
+    <property name="close-response">close</property>
 
-    <property name="content">
+    <responses>
+      <response id="close" translatable="yes">_Cancel</response>
+      <response id="rename" translatable="yes" appearance="destructive">_Rename</response>
+    </responses>
+
+    <property name="extra-child">
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <property name="margin-top">12</property>
+        <property name="width-request">500</property>
 
-        <!-- Headerbar -->
         <child>
-          <object class="AdwHeaderBar">
+          <object class="AdwPreferencesGroup">
 
-            <child type="start">
-              <object class="GtkButton" id="button_cancel">
-                <property name="action-name">container-rename-dialog.cancel</property>
-                <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-underline">True</property>
-              </object>
-            </child>
-
-            <child type="title">
-              <object class="AdwWindowTitle">
-                <property name="title"/>
-              </object>
-            </child>
-
-            <child type="end">
-              <object class="GtkButton" id="button_rename">
-                <style>
-                  <class name="suggested-action"/>
-                </style>
-                <property name="action-name">container-rename-dialog.rename</property>
-                <property name="label" translatable="yes">_Rename</property>
-                <property name="use-underline">True</property>
+            <child>
+              <object class="PdsRandomNameEntryRow" id="entry_row">
+                <property name="activates-default">True</property>
+                <property name="title" translatable="yes">Name</property>
               </object>
             </child>
 
@@ -44,70 +29,20 @@
         </child>
 
         <child>
-          <object class="AdwPreferencesPage">
+          <object class="GtkRevealer" id="error_label_revealer">
+            <property name="visible">False</property>
 
             <child>
-              <object class="AdwPreferencesGroup">
-
-                <child>
-                  <object class="PdsRandomNameEntryRow" id="entry_row">
-                    <property name="activates-default">True</property>
-                    <property name="title" translatable="yes">Name</property>
-                  </object>
-                </child>
-
-                <child>
-                  <object class="AdwPreferencesRow" id="error_label_row">
-                    <property name="activatable">False</property>
-                    <property name="visible">False</property>
-
-                    <child>
-                      <object class="GtkRevealer" id="error_label_revealer">
-
-                        <child>
-                          <object class="GtkLabel" id="error_label">
-                            <style>
-                              <class name="error"/>
-                            </style>
-                            <property name="justify">center</property>
-                            <property name="margin-bottom">12</property>
-                            <property name="margin-end">12</property>
-                            <property name="margin-start">12</property>
-                            <property name="margin-top">12</property>
-                            <property name="wrap">True</property>
-                            <property name="wrap-mode">word-char</property>
-                          </object>
-                        </child>
-
-                      </object>
-                    </child>
-
-                  </object>
-                </child>
-
-              </object>
-            </child>
-
-            <child>
-              <object class="AdwPreferencesGroup">
-
-                <child>
-                  <object class="PdsPropertyRow" id="id_row">
-                    <property name="key" translatable="yes">Id</property>
-                  </object>
-                </child>
-
-                <child>
-                  <object class="PdsPropertyRow">
-                    <property name="key" translatable="yes">Current Name</property>
-                    <binding name="value">
-                      <lookup name="name" type="Container">
-                        <lookup name="container">PdsContainerRenameDialog</lookup>
-                      </lookup>
-                    </binding>
-                  </object>
-                </child>
-
+              <object class="GtkLabel" id="error_label">
+                <style>
+                  <class name="error"/>
+                </style>
+                <property name="justify">center</property>
+                <property name="margin-end">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-top">24</property>
+                <property name="wrap">True</property>
+                <property name="wrap-mode">word-char</property>
               </object>
             </child>
 

--- a/src/view/container/rename_dialog.rs
+++ b/src/view/container/rename_dialog.rs
@@ -1,4 +1,7 @@
+use std::cell::RefCell;
+
 use adw::subclass::prelude::*;
+use adw::traits::MessageDialogExt;
 use gtk::gdk;
 use gtk::glib;
 use gtk::glib::clone;
@@ -6,44 +9,40 @@ use gtk::glib::closure;
 use gtk::prelude::*;
 use gtk::CompositeTemplate;
 use once_cell::sync::Lazy;
+use once_cell::unsync::OnceCell;
 
 use crate::model;
 use crate::view;
 
 mod imp {
+    use gettextrs::gettext;
+
     use super::*;
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/marhkb/Pods/ui/container/rename-dialog.ui")]
     pub(crate) struct RenameDialog {
         pub(super) container: glib::WeakRef<model::Container>,
+        pub(super) response: RefCell<Option<String>>,
+        pub(super) rename_finished: OnceCell<()>,
         #[template_child]
         pub(super) entry_row: TemplateChild<view::RandomNameEntryRow>,
-        #[template_child]
-        pub(super) error_label_row: TemplateChild<adw::PreferencesRow>,
+        // #[template_child]
+        // pub(super) error_label_row: TemplateChild<adw::PreferencesRow>,
         #[template_child]
         pub(super) error_label_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
         pub(super) error_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub(super) id_row: TemplateChild<view::PropertyRow>,
     }
 
     #[glib::object_subclass]
     impl ObjectSubclass for RenameDialog {
         const NAME: &'static str = "PdsContainerRenameDialog";
         type Type = super::RenameDialog;
-        type ParentType = adw::Window;
+        type ParentType = adw::MessageDialog;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
-
-            klass.install_action("container-rename-dialog.cancel", None, |widget, _, _| {
-                widget.cancel();
-            });
-            klass.install_action("container-rename-dialog.rename", None, |widget, _, _| {
-                widget.rename();
-            });
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -82,13 +81,64 @@ mod imp {
 
             let obj = &*self.obj();
 
+            obj.connect_response(None, |obj, response| {
+                obj.imp().response.replace(Some(response.to_owned()));
+            });
+
+            obj.connect_close_request(|obj| {
+                let imp = obj.imp();
+
+                if imp.rename_finished.get().is_some() {
+                    return gtk::Inhibit(false);
+                }
+
+                match imp.response.take() {
+                    Some(response) => {
+                        if &response == "close" {
+                            return gtk::Inhibit(false);
+                        }
+
+                        if let Some(container) = imp.container.upgrade() {
+                            let new_name = imp.entry_row.text().to_string();
+                            container.rename(
+                                new_name,
+                                clone!(@weak obj => move |result| {
+                                    let imp = obj.imp();
+                                    match result {
+                                        Ok(_) => {
+                                            imp.rename_finished.set(()).unwrap();
+                                            obj.close();
+                                        },
+                                        Err(e) => {
+                                            imp.entry_row.add_css_class("error");
+                                            imp.error_label_revealer.set_visible(true);
+                                            imp.error_label_revealer.set_reveal_child(true);
+                                            imp.error_label.set_text(&e.to_string());
+                                        }
+                                    }
+                                }),
+                            );
+                        }
+
+                        gtk::Inhibit(true)
+                    }
+                    None => {
+                        glib::idle_add_local_once(clone!(@weak obj => move || {
+                            obj.close();
+                        }));
+                        gtk::Inhibit(true)
+                    }
+                }
+            });
+
             let key_events = gtk::EventControllerKey::new();
             obj.add_controller(&key_events);
             key_events.connect_key_pressed(
                 clone!(@weak obj => @default-return gtk::Inhibit(false), move |_, key, _, _| {
                     gtk::Inhibit(
                         if key == gdk::Key::Escape {
-                            obj.cancel();
+                            obj.imp().response.replace(Some("close".to_string()));
+                            obj.close();
                             true
                         } else {
                             false
@@ -102,40 +152,44 @@ mod imp {
                 self.entry_row.grab_focus();
             }
 
-            obj.action_set_enabled("container.rename", !self.entry_row.text().is_empty());
             self.entry_row
                 .connect_changed(clone!(@weak obj => move |entry| {
                     let imp = obj.imp();
                     imp.entry_row.remove_css_class("error");
                     imp.error_label_revealer.set_reveal_child(false);
-                    obj.action_set_enabled("container.rename", !entry.text().is_empty());
+                    obj.set_response_enabled("rename", !entry.text().is_empty());
                 }));
 
             self.error_label_revealer.connect_child_revealed_notify(
                 clone!(@weak obj => move |revealer| {
                     if !revealer.reveals_child() {
-                        obj.imp().error_label_row.set_visible(false);
+                        revealer.set_visible(false);
                     }
                 }),
             );
 
+            obj.set_heading_use_markup(true);
             Self::Type::this_expression("container")
-                .chain_property::<model::Container>("id")
-                .chain_closure::<String>(closure!(|_: Self::Type, id: String| {
-                    id.chars().take(12).collect::<String>()
+                .chain_property::<model::Container>("name")
+                .chain_closure::<String>(closure!(|_: Self::Type, name: String| {
+                    format!(
+                        "{}\n<span weight=\"bold\">«{}»</span>",
+                        gettext("Rename Container"),
+                        name
+                    )
                 }))
-                .bind(&*self.id_row, "value", Some(obj));
+                .bind(obj, "heading", Some(obj));
         }
     }
 
     impl WidgetImpl for RenameDialog {}
     impl WindowImpl for RenameDialog {}
-    impl AdwWindowImpl for RenameDialog {}
+    impl MessageDialogImpl for RenameDialog {}
 }
 
 glib::wrapper! {
     pub(crate) struct RenameDialog(ObjectSubclass<imp::RenameDialog>)
-        @extends gtk::Widget, gtk::Window, adw::Window,
+        @extends gtk::Widget, gtk::Window, adw::MessageDialog,
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget, gtk::Native, gtk::Root, gtk::ShortcutManager;
 }
 
@@ -144,34 +198,5 @@ impl From<Option<model::Container>> for RenameDialog {
         glib::Object::builder::<Self>()
             .property("container", &container)
             .build()
-    }
-}
-
-impl RenameDialog {
-    fn cancel(&self) {
-        self.close();
-    }
-
-    fn rename(&self) {
-        let imp = self.imp();
-
-        if let Some(container) = imp.container.upgrade() {
-            let new_name = imp.entry_row.text().to_string();
-            container.rename(
-                new_name,
-                clone!(@weak self as obj => move |result| {
-                    match result {
-                        Ok(_) => obj.close(),
-                        Err(e) => {
-                            let imp = obj.imp();
-                            imp.entry_row.add_css_class("error");
-                            imp.error_label_row.set_visible(true);
-                            imp.error_label_revealer.set_reveal_child(true);
-                            imp.error_label.set_text(&e.to_string());
-                        }
-                    }
-                }),
-            )
-        }
     }
 }


### PR DESCRIPTION
Fixes #331