### PR TITLE
Feat/retry-failed-action

### DIFF
--- a/data/resources/ui/action/page.ui
+++ b/data/resources/ui/action/page.ui
@@ -28,10 +28,6 @@
             </style>
             <property name="valign">start</property>
 
-            <child type="start">
-              <object class="PdsBackNavigationControls"/>
-            </child>
-
             <child type="title">
               <object class="AdwWindowTitle">
                 <property name="title" translatable="yes"></property>

--- a/data/resources/ui/action/page.ui
+++ b/data/resources/ui/action/page.ui
@@ -137,6 +137,21 @@
                       </object>
                     </child>
 
+                    <child>
+                      <object class="GtkButton" id="retry_button">
+                        <style>
+                          <class name="pill"/>
+                          <class name="suggested-action"/>
+                        </style>
+                        <property name="action-name">action-page.retry</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">_Retry</property>
+                        <property name="use-underline">True</property>
+                        <property name="visible" bind-source="retry_button" bind-property="sensitive" bind-flags="sync-create"/>
+                        <property name="width-request">200</property>
+                      </object>
+                    </child>
+
                   </object>
                 </property>
 

--- a/src/view/action/page.rs
+++ b/src/view/action/page.rs
@@ -12,7 +12,7 @@ use crate::utils;
 use crate::view;
 
 const ACTION_CANCEL: &str = "action-page.cancel";
-const ACTION_VIEW_IMAGE: &str = "action-page.view-artifact";
+const ACTION_VIEW_ARTIFACT: &str = "action-page.view-artifact";
 
 mod imp {
     use super::*;
@@ -34,7 +34,7 @@ mod imp {
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
             klass.install_action(ACTION_CANCEL, None, |widget, _, _| widget.cancel());
-            klass.install_action(ACTION_VIEW_IMAGE, None, move |widget, _, _| {
+            klass.install_action(ACTION_VIEW_ARTIFACT, None, move |widget, _, _| {
                 widget.view_artifact();
             });
         }
@@ -190,7 +190,7 @@ impl Page {
 
         self.action_set_enabled(ACTION_CANCEL, action.state() == Ongoing);
         self.action_set_enabled(
-            ACTION_VIEW_IMAGE,
+            ACTION_VIEW_ARTIFACT,
             action.state() == Finished
                 && !matches!(action.type_(), PruneImages | Commit | CopyFiles),
         );


### PR DESCRIPTION
At the moment, this only works immediately after submitting the settings
for the action and not after the action page has been created later by
clicking in the notification area.

Fixes #478