### PR TITLE
refactor: Cleanup GObject builder methods

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -108,10 +108,10 @@ glib::wrapper! {
 
 impl Default for Application {
     fn default() -> Self {
-        glib::Object::builder::<Self>()
-            .property("application-id", &Some(config::APP_ID))
-            .property("flags", &gio::ApplicationFlags::empty())
-            .property("resource-base-path", &Some("/com/github/marhkb/Pods/"))
+        glib::Object::builder()
+            .property("application-id", Some(config::APP_ID))
+            .property("flags", gio::ApplicationFlags::empty())
+            .property("resource-base-path", Some("/com/github/marhkb/Pods/"))
             .build()
     }
 }

--- a/src/model/action.rs
+++ b/src/model/action.rs
@@ -142,13 +142,13 @@ impl Action {
 
 impl Action {
     fn new(num: u32, type_: Type, description: &str) -> Self {
-        glib::Object::builder::<Self>()
-            .property("num", &num)
-            .property("type", &type_)
-            .property("description", &description)
+        glib::Object::builder()
+            .property("num", num)
+            .property("type", type_)
+            .property("description", description)
             .property(
                 "start-timestamp",
-                &glib::DateTime::now_local().unwrap().to_unix(),
+                glib::DateTime::now_local().unwrap().to_unix(),
             )
             .build()
     }

--- a/src/model/action_list.rs
+++ b/src/model/action_list.rs
@@ -103,11 +103,9 @@ glib::wrapper! {
         @implements gio::ListModel;
 }
 
-impl From<Option<&model::Client>> for ActionList {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for ActionList {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/model/client.rs
+++ b/src/model/client.rs
@@ -167,9 +167,9 @@ impl TryFrom<&model::Connection> for Client {
 
     fn try_from(connection: &model::Connection) -> Result<Self, Self::Error> {
         podman::Podman::new(connection.url()).map(|podman| {
-            glib::Object::builder::<Self>()
+            glib::Object::builder()
                 .property("connection", connection)
-                .property("podman", &BoxedPodman::from(podman))
+                .property("podman", BoxedPodman::from(podman))
                 .build()
         })
     }
@@ -187,25 +187,25 @@ impl Client {
     pub(crate) fn image_list(&self) -> &model::ImageList {
         self.imp()
             .image_list
-            .get_or_init(|| model::ImageList::from(Some(self)))
+            .get_or_init(|| model::ImageList::from(self))
     }
 
     pub(crate) fn container_list(&self) -> &model::ContainerList {
         self.imp()
             .container_list
-            .get_or_init(|| model::ContainerList::from(Some(self)))
+            .get_or_init(|| model::ContainerList::from(self))
     }
 
     pub(crate) fn pod_list(&self) -> &model::PodList {
         self.imp()
             .pod_list
-            .get_or_init(|| model::PodList::from(Some(self)))
+            .get_or_init(|| model::PodList::from(self))
     }
 
     pub(crate) fn action_list(&self) -> &model::ActionList {
         self.imp()
             .action_list
-            .get_or_init(|| model::ActionList::from(Some(self)))
+            .get_or_init(|| model::ActionList::from(self))
     }
 
     pub(crate) fn check_service<T, E, F>(&self, op: T, err_op: E, finish_op: F)

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -133,12 +133,12 @@ impl Connection {
         rgb: Option<gdk::RGBA>,
         manager: &model::ConnectionManager,
     ) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("manager", manager)
-            .property("uuid", &uuid)
-            .property("name", &name)
-            .property("url", &url)
-            .property("rgb", &rgb)
+            .property("uuid", uuid)
+            .property("name", name)
+            .property("url", url)
+            .property("rgb", rgb)
             .build()
     }
 

--- a/src/model/connection_manager.rs
+++ b/src/model/connection_manager.rs
@@ -86,7 +86,7 @@ glib::wrapper! {
 
 impl Default for ConnectionManager {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/container.rs
+++ b/src/model/container.rs
@@ -304,24 +304,24 @@ impl Container {
         container_list: &model::ContainerList,
         list_container: podman::models::ListContainer,
     ) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("container-list", container_list)
             .property(
                 "created",
-                &list_container.created.map(|dt| dt.timestamp()).unwrap_or(0),
+                list_container.created.map(|dt| dt.timestamp()).unwrap_or(0),
             )
             .property(
                 "health-status",
                 &health_status(list_container.status.as_deref()),
             )
-            .property("id", &list_container.id)
-            .property("image-id", &list_container.image_id)
-            .property("image-name", &list_container.image)
+            .property("id", list_container.id)
+            .property("image-id", list_container.image_id)
+            .property("image-name", list_container.image)
             .property("name", &list_container.names.unwrap()[0])
-            .property("pod-id", &list_container.pod)
+            .property("pod-id", list_container.pod)
             .property(
                 "port",
-                &list_container
+                list_container
                     .ports
                     .unwrap_or_default()
                     .first()
@@ -333,8 +333,8 @@ impl Container {
                         )
                     }),
             )
-            .property("status", &status(list_container.state.as_deref()))
-            .property("up-since", &list_container.started_at.unwrap())
+            .property("status", status(list_container.state.as_deref()))
+            .property("up-since", list_container.started_at.unwrap())
             .build()
     }
 

--- a/src/model/container_data.rs
+++ b/src/model/container_data.rs
@@ -93,15 +93,14 @@ impl From<podman::models::InspectContainerData> for ContainerData {
         let obj: Self = glib::Object::builder()
             .property(
                 "health-config",
-                &data
-                    .config
+                data.config
                     .unwrap()
                     .healthcheck
                     .map(BoxedSchema2HealthConfig),
             )
             .property(
                 "health-failing-streak",
-                &health_failing_streak(data.state.as_ref()),
+                health_failing_streak(data.state.as_ref()),
             )
             .property(
                 "port-bindings",

--- a/src/model/container_list.rs
+++ b/src/model/container_list.rs
@@ -184,11 +184,9 @@ glib::wrapper! {
         @implements gio::ListModel, model::AbstractContainerList, model::SelectableList;
 }
 
-impl From<Option<&model::Client>> for ContainerList {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for ContainerList {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -89,10 +89,10 @@ glib::wrapper! {
 
 impl Default for Device {
     fn default() -> Self {
-        glib::Object::builder::<Self>()
-            .property("readable", &true)
-            .property("writable", &false)
-            .property("mknod", &false)
+        glib::Object::builder()
+            .property("readable", true)
+            .property("writable", false)
+            .property("mknod", false)
             .build()
     }
 }

--- a/src/model/health_check_log.rs
+++ b/src/model/health_check_log.rs
@@ -76,9 +76,9 @@ glib::wrapper! {
 
 impl From<&podman::models::HealthCheckLog> for HealthCheckLog {
     fn from(data: &podman::models::HealthCheckLog) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("end", data.end.as_ref().unwrap())
-            .property("exit-code", &data.exit_code.unwrap())
+            .property("exit-code", data.exit_code.unwrap())
             .property("output", data.output.as_ref().unwrap())
             .property("start", data.start.as_ref().unwrap())
             .build()

--- a/src/model/health_check_log_list.rs
+++ b/src/model/health_check_log_list.rs
@@ -52,7 +52,7 @@ glib::wrapper! {
 
 impl Default for HealthCheckLogList {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -152,9 +152,9 @@ impl Image {
     ) -> Self {
         glib::Object::builder::<Self>()
             .property("image-list", image_list)
-            .property("created", &summary.created.unwrap_or(0))
+            .property("created", summary.created.unwrap_or(0))
             .property("id", &summary.id)
-            .property("size", &(summary.size.unwrap_or_default() as u64))
+            .property("size", summary.size.unwrap_or_default() as u64)
             .build()
             .update_internal(summary, false)
             .to_owned()

--- a/src/model/image_config.rs
+++ b/src/model/image_config.rs
@@ -69,21 +69,21 @@ glib::wrapper! {
 
 impl ImageConfig {
     pub(crate) fn from_libpod(config: podman::models::ImageConfig) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property(
                 "cmd",
-                &utils::format_iter_or_none(config.cmd.as_deref().unwrap_or_default().iter(), " "),
+                utils::format_iter_or_none(config.cmd.as_deref().unwrap_or_default().iter(), " "),
             )
             .property(
                 "entrypoint",
-                &utils::format_iter_or_none(
+                utils::format_iter_or_none(
                     config.entrypoint.as_deref().unwrap_or_default().iter(),
                     " ",
                 ),
             )
             .property(
                 "exposed-ports",
-                &gtk::StringList::new(
+                gtk::StringList::new(
                     &config
                         .exposed_ports
                         .unwrap_or_default()

--- a/src/model/image_data.rs
+++ b/src/model/image_data.rs
@@ -75,13 +75,13 @@ glib::wrapper! {
 
 impl From<podman::models::ImageData> for ImageData {
     fn from(data: podman::models::ImageData) -> Self {
-        glib::Object::builder::<Self>()
-            .property("architecture", &data.architecture)
-            .property("author", &data.author)
-            .property("comment", &data.comment)
+        glib::Object::builder()
+            .property("architecture", data.architecture)
+            .property("author", data.author)
+            .property("comment", data.comment)
             .property(
                 "config",
-                &model::ImageConfig::from_libpod(data.config.unwrap()),
+                model::ImageConfig::from_libpod(data.config.unwrap()),
             )
             .build()
     }

--- a/src/model/image_list.rs
+++ b/src/model/image_list.rs
@@ -125,11 +125,9 @@ glib::wrapper! {
         @implements gio::ListModel, model::SelectableList;
 }
 
-impl From<Option<&model::Client>> for ImageList {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for ImageList {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/model/image_search_response.rs
+++ b/src/model/image_search_response.rs
@@ -92,14 +92,14 @@ glib::wrapper! {
 
 impl From<podman::models::RegistrySearchResponse> for ImageSearchResponse {
     fn from(response: podman::models::RegistrySearchResponse) -> Self {
-        glib::Object::builder::<Self>()
-            .property("automated", &response.automated)
-            .property("description", &response.description)
-            .property("index", &response.index)
-            .property("name", &response.name)
-            .property("official", &response.official)
-            .property("stars", &response.stars.unwrap_or(-1))
-            .property("tag", &response.tag)
+        glib::Object::builder()
+            .property("automated", response.automated)
+            .property("description", response.description)
+            .property("index", response.index)
+            .property("name", response.name)
+            .property("official", response.official)
+            .property("stars", response.stars.unwrap_or(-1))
+            .property("tag", response.tag)
             .build()
     }
 }

--- a/src/model/key_val.rs
+++ b/src/model/key_val.rs
@@ -70,7 +70,7 @@ glib::wrapper! {
 
 impl Default for KeyVal {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/pod.rs
+++ b/src/model/pod.rs
@@ -208,19 +208,19 @@ glib::wrapper! {
 
 impl Pod {
     pub(crate) fn new(pod_list: &model::PodList, report: podman::models::ListPodsReport) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("pod-list", pod_list)
             .property(
                 "created",
-                &report.created.map(|dt| dt.timestamp()).unwrap_or(0),
+                report.created.map(|dt| dt.timestamp()).unwrap_or(0),
             )
-            .property("id", &report.id.unwrap())
-            .property("name", &report.name.unwrap())
+            .property("id", report.id.unwrap())
+            .property("name", report.name.unwrap())
             .property(
                 "num-containers",
                 &report.containers.map(|c| c.len() as u64).unwrap_or(0),
             )
-            .property("status", &status(report.status.as_deref()))
+            .property("status", status(report.status.as_deref()))
             .build()
     }
 

--- a/src/model/pod_data.rs
+++ b/src/model/pod_data.rs
@@ -53,8 +53,8 @@ glib::wrapper! {
 
 impl From<podman::models::InspectPodData> for PodData {
     fn from(data: podman::models::InspectPodData) -> Self {
-        glib::Object::builder::<Self>()
-            .property("hostname", &data.hostname.unwrap_or_default())
+        glib::Object::builder()
+            .property("hostname", data.hostname.unwrap_or_default())
             .build()
     }
 }

--- a/src/model/pod_list.rs
+++ b/src/model/pod_list.rs
@@ -123,11 +123,9 @@ glib::wrapper! {
         @implements gio::ListModel, model::SelectableList;
 }
 
-impl From<Option<&model::Client>> for PodList {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for PodList {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/model/port_mapping.rs
+++ b/src/model/port_mapping.rs
@@ -107,7 +107,7 @@ glib::wrapper! {
 
 impl Default for PortMapping {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/registry.rs
+++ b/src/model/registry.rs
@@ -52,9 +52,7 @@ glib::wrapper! {
 
 impl From<&str> for Registry {
     fn from(name: &str) -> Self {
-        glib::Object::builder::<Self>()
-            .property("name", &name)
-            .build()
+        glib::Object::builder().property("name", name).build()
     }
 }
 

--- a/src/model/repo_tag.rs
+++ b/src/model/repo_tag.rs
@@ -75,7 +75,7 @@ glib::wrapper! {
 
 impl RepoTag {
     pub(crate) fn new(repo_tag_list: &model::RepoTagList, full: &str) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("repo-tag-list", repo_tag_list)
             .property("full", full)
             .build()

--- a/src/model/repo_tag_list.rs
+++ b/src/model/repo_tag_list.rs
@@ -84,9 +84,7 @@ glib::wrapper! {
 
 impl From<&model::Image> for RepoTagList {
     fn from(image: &model::Image) -> Self {
-        glib::Object::builder::<Self>()
-            .property("image", image)
-            .build()
+        glib::Object::builder().property("image", image).build()
     }
 }
 

--- a/src/model/simple_container_list.rs
+++ b/src/model/simple_container_list.rs
@@ -91,7 +91,7 @@ glib::wrapper! {
 
 impl Default for SimpleContainerList {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -58,7 +58,7 @@ glib::wrapper! {
 
 impl Default for Value {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -105,9 +105,7 @@ glib::wrapper! {
 
 impl Default for Volume {
     fn default() -> Self {
-        glib::Object::builder::<Self>()
-            .property("writable", &true)
-            .build()
+        glib::Object::builder().property("writable", true).build()
     }
 }
 

--- a/src/view/action/page.rs
+++ b/src/view/action/page.rs
@@ -120,9 +120,7 @@ glib::wrapper! {
 
 impl From<&model::Action> for Page {
     fn from(action: &model::Action) -> Self {
-        glib::Object::builder::<Self>()
-            .property("action", &action)
-            .build()
+        glib::Object::builder().property("action", action).build()
     }
 }
 

--- a/src/view/actions/overview.rs
+++ b/src/view/actions/overview.rs
@@ -125,7 +125,7 @@ glib::wrapper! {
 
 impl Default for Overview {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/component/circular_progress_bar.rs
+++ b/src/view/component/circular_progress_bar.rs
@@ -244,7 +244,7 @@ glib::wrapper! {
 
 impl Default for CircularProgressBar {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/component/leaflet_overlay.rs
+++ b/src/view/component/leaflet_overlay.rs
@@ -61,7 +61,7 @@ glib::wrapper! {
 
 impl Default for LeafletOverlay {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/component/property_row.rs
+++ b/src/view/component/property_row.rs
@@ -109,13 +109,13 @@ glib::wrapper! {
 
 impl Default for PropertyRow {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 
 impl PropertyRow {
     pub(crate) fn new(key: &str, value: &str) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("key", key)
             .property("value", value)
             .build()

--- a/src/view/component/property_widget_row.rs
+++ b/src/view/component/property_widget_row.rs
@@ -96,7 +96,7 @@ glib::wrapper! {
 
 impl Default for PropertyWidgetRow {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/component/source_view_page.rs
+++ b/src/view/component/source_view_page.rs
@@ -163,7 +163,7 @@ glib::wrapper! {
 
 impl From<Entity> for SourceViewPage {
     fn from(entity: Entity) -> Self {
-        let obj: Self = glib::Object::builder::<Self>().build();
+        let obj: Self = glib::Object::builder().build();
         let imp = obj.imp();
 
         match &entity {

--- a/src/view/component/top_page.rs
+++ b/src/view/component/top_page.rs
@@ -106,7 +106,7 @@ glib::wrapper! {
 
 impl From<&model::Container> for TopPage {
     fn from(container: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("top-source", container)
             .build()
     }
@@ -114,9 +114,7 @@ impl From<&model::Container> for TopPage {
 
 impl From<&model::Pod> for TopPage {
     fn from(pod: &model::Pod) -> Self {
-        glib::Object::builder::<Self>()
-            .property("top-source", pod)
-            .build()
+        glib::Object::builder().property("top-source", pod).build()
     }
 }
 

--- a/src/view/connection/creation_page.rs
+++ b/src/view/connection/creation_page.rs
@@ -165,7 +165,7 @@ glib::wrapper! {
 
 impl From<&model::ConnectionManager> for CreationPage {
     fn from(connection_manager: &model::ConnectionManager) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("connection-manager", connection_manager)
             .build()
     }

--- a/src/view/connection/custom_info_dialog.rs
+++ b/src/view/connection/custom_info_dialog.rs
@@ -106,7 +106,7 @@ glib::wrapper! {
 
 impl Default for CustomInfoDialog {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/connection/switcher_widget.rs
+++ b/src/view/connection/switcher_widget.rs
@@ -116,7 +116,7 @@ glib::wrapper! {
 
 impl Default for SwitcherWidget {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/container/commit_page.rs
+++ b/src/view/container/commit_page.rs
@@ -162,8 +162,8 @@ glib::wrapper! {
 
 impl From<&model::Container> for CommitPage {
     fn from(container: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", &container)
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/creation_page.rs
+++ b/src/view/container/creation_page.rs
@@ -402,25 +402,19 @@ glib::wrapper! {
 
 impl From<&model::Image> for CreationPage {
     fn from(image: &model::Image) -> Self {
-        glib::Object::builder::<Self>()
-            .property("image", &image)
-            .build()
+        glib::Object::builder().property("image", image).build()
     }
 }
 
 impl From<&model::Pod> for CreationPage {
     fn from(pod: &model::Pod) -> Self {
-        glib::Object::builder::<Self>()
-            .property("pod", &pod)
-            .build()
+        glib::Object::builder().property("pod", pod).build()
     }
 }
 
 impl From<&model::Client> for CreationPage {
     fn from(client: &model::Client) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", client)
-            .build()
+        glib::Object::builder().property("client", client).build()
     }
 }
 
@@ -547,20 +541,24 @@ impl CreationPage {
     }
 
     fn search_image(&self) {
-        let image_selection_page = view::ImageSelectionPage::from(self.client().as_ref());
-        image_selection_page.connect_image_selected(clone!(@weak self as obj => move |_, image| {
-            let imp = obj.imp();
+        if let Some(client) = self.client() {
+            let image_selection_page = view::ImageSelectionPage::from(&client);
+            image_selection_page.connect_image_selected(
+                clone!(@weak self as obj => move |_, image| {
+                    let imp = obj.imp();
 
-            imp.local_image_combo_row.set_visible(false);
-            imp.remote_image_row.set_visible(true);
-            imp.remote_image_row.set_subtitle(&image);
-            imp.pull_latest_image_row.set_visible(false);
+                    imp.local_image_combo_row.set_visible(false);
+                    imp.remote_image_row.set_visible(true);
+                    imp.remote_image_row.set_subtitle(&image);
+                    imp.pull_latest_image_row.set_visible(false);
 
-            imp.command_entry_row.set_text("");
-        }));
-        self.imp()
-            .leaflet_overlay
-            .show_details(&image_selection_page);
+                    imp.command_entry_row.set_text("");
+                }),
+            );
+            self.imp()
+                .leaflet_overlay
+                .show_details(&image_selection_page);
+        }
     }
 
     fn add_cmd_arg(&self) {

--- a/src/view/container/details_page.rs
+++ b/src/view/container/details_page.rs
@@ -252,9 +252,9 @@ glib::wrapper! {
 }
 
 impl From<&model::Container> for DetailsPage {
-    fn from(image: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", image)
+    fn from(container: &model::Container) -> Self {
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }
@@ -319,9 +319,11 @@ impl DetailsPage {
     }
 
     fn rename(&self) {
-        let dialog = view::ContainerRenameDialog::from(self.container());
-        dialog.set_transient_for(Some(&utils::root(self)));
-        dialog.present();
+        if let Some(container) = self.container() {
+            let dialog = view::ContainerRenameDialog::from(&container);
+            dialog.set_transient_for(Some(&utils::root(self)));
+            dialog.present();
+        }
     }
 
     fn commit(&self) {

--- a/src/view/container/files_get_page.rs
+++ b/src/view/container/files_get_page.rs
@@ -135,8 +135,8 @@ glib::wrapper! {
 
 impl From<&model::Container> for FilesGetPage {
     fn from(container: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", &container)
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/files_put_page.rs
+++ b/src/view/container/files_put_page.rs
@@ -146,8 +146,8 @@ glib::wrapper! {
 
 impl From<&model::Container> for FilesPutPage {
     fn from(container: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", &container)
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/health_check_page.rs
+++ b/src/view/container/health_check_page.rs
@@ -171,9 +171,9 @@ glib::wrapper! {
 }
 
 impl From<&model::Container> for HealthCheckPage {
-    fn from(image: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", image)
+    fn from(container: &model::Container) -> Self {
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/log_page.rs
+++ b/src/view/container/log_page.rs
@@ -278,9 +278,9 @@ glib::wrapper! {
 }
 
 impl From<&model::Container> for LogPage {
-    fn from(image: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", image)
+    fn from(container: &model::Container) -> Self {
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/menu_button.rs
+++ b/src/view/container/menu_button.rs
@@ -185,8 +185,10 @@ impl MenuButton {
     }
 
     fn rename(&self) {
-        let dialog = view::ContainerRenameDialog::from(self.container());
-        dialog.set_transient_for(Some(&utils::root(self)));
-        dialog.present();
+        if let Some(container) = self.container() {
+            let dialog = view::ContainerRenameDialog::from(&container);
+            dialog.set_transient_for(Some(&utils::root(self)));
+            dialog.present();
+        }
     }
 }

--- a/src/view/container/rename_dialog.rs
+++ b/src/view/container/rename_dialog.rs
@@ -26,8 +26,6 @@ mod imp {
         pub(super) rename_finished: OnceCell<()>,
         #[template_child]
         pub(super) entry_row: TemplateChild<view::RandomNameEntryRow>,
-        // #[template_child]
-        // pub(super) error_label_row: TemplateChild<adw::PreferencesRow>,
         #[template_child]
         pub(super) error_label_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
@@ -197,10 +195,10 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget, gtk::Native, gtk::Root, gtk::ShortcutManager;
 }
 
-impl From<Option<model::Container>> for RenameDialog {
-    fn from(container: Option<model::Container>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container", &container)
+impl From<&model::Container> for RenameDialog {
+    fn from(container: &model::Container) -> Self {
+        glib::Object::builder()
+            .property("container", container)
             .build()
     }
 }

--- a/src/view/container/row.rs
+++ b/src/view/container/row.rs
@@ -265,7 +265,7 @@ glib::wrapper! {
 
 impl From<&model::Container> for Row {
     fn from(container: &model::Container) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("container", container)
             .build()
     }

--- a/src/view/containers/count_bar.rs
+++ b/src/view/containers/count_bar.rs
@@ -140,9 +140,9 @@ glib::wrapper! {
 }
 
 impl From<&model::AbstractContainerList> for CountBar {
-    fn from(image: &model::AbstractContainerList) -> Self {
-        glib::Object::builder::<Self>()
-            .property("container-list", image)
+    fn from(container_list: &model::AbstractContainerList) -> Self {
+        glib::Object::builder()
+            .property("container-list", container_list)
             .build()
     }
 }

--- a/src/view/containers/group.rs
+++ b/src/view/containers/group.rs
@@ -186,7 +186,7 @@ glib::wrapper! {
 
 impl Default for Group {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/containers/panel.rs
+++ b/src/view/containers/panel.rs
@@ -185,7 +185,7 @@ glib::wrapper! {
 
 impl Default for Panel {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/device/row.rs
+++ b/src/view/device/row.rs
@@ -86,9 +86,7 @@ glib::wrapper! {
 
 impl From<&model::Device> for Row {
     fn from(device: &model::Device) -> Self {
-        glib::Object::builder::<Self>()
-            .property("device", &device)
-            .build()
+        glib::Object::builder().property("device", device).build()
     }
 }
 

--- a/src/view/health_check_log/row.rs
+++ b/src/view/health_check_log/row.rs
@@ -89,9 +89,7 @@ glib::wrapper! {
 
 impl From<&model::HealthCheckLog> for Row {
     fn from(log: &model::HealthCheckLog) -> Self {
-        glib::Object::builder::<Self>()
-            .property("log", &log)
-            .build()
+        glib::Object::builder().property("log", log).build()
     }
 }
 

--- a/src/view/image/build_page.rs
+++ b/src/view/image/build_page.rs
@@ -171,9 +171,7 @@ glib::wrapper! {
 
 impl From<&model::Client> for BuildPage {
     fn from(client: &model::Client) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", client)
-            .build()
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/view/image/details_page.rs
+++ b/src/view/image/details_page.rs
@@ -279,9 +279,7 @@ glib::wrapper! {
 
 impl From<&model::Image> for DetailsPage {
     fn from(image: &model::Image) -> Self {
-        glib::Object::builder::<Self>()
-            .property("image", image)
-            .build()
+        glib::Object::builder().property("image", image).build()
     }
 }
 

--- a/src/view/image/pull_page.rs
+++ b/src/view/image/pull_page.rs
@@ -113,9 +113,7 @@ glib::wrapper! {
 
 impl From<&model::Client> for PullPage {
     fn from(client: &model::Client) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", client)
-            .build()
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/view/image/row.rs
+++ b/src/view/image/row.rs
@@ -159,9 +159,7 @@ glib::wrapper! {
 
 impl From<&model::Image> for Row {
     fn from(image: &model::Image) -> Self {
-        glib::Object::builder::<Self>()
-            .property("image", image)
-            .build()
+        glib::Object::builder().property("image", image).build()
     }
 }
 

--- a/src/view/image/selection_page.rs
+++ b/src/view/image/selection_page.rs
@@ -109,11 +109,9 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
-impl From<Option<&model::Client>> for SelectionPage {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for SelectionPage {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/view/images/panel.rs
+++ b/src/view/images/panel.rs
@@ -281,7 +281,7 @@ glib::wrapper! {
 
 impl Default for Panel {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/images/prune_page.rs
+++ b/src/view/images/prune_page.rs
@@ -215,9 +215,7 @@ glib::wrapper! {
 
 impl From<&model::Client> for PrunePage {
     fn from(client: &model::Client) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", client)
-            .build()
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/view/info_dialog.rs
+++ b/src/view/info_dialog.rs
@@ -126,11 +126,9 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget, gtk::Native, gtk::Root, gtk::ShortcutManager;
 }
 
-impl From<Option<&model::Client>> for InfoDialog {
-    fn from(client: Option<&model::Client>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", &client)
-            .build()
+impl From<&model::Client> for InfoDialog {
+    fn from(client: &model::Client) -> Self {
+        glib::Object::builder().property("client", client).build()
     }
 }
 

--- a/src/view/key_val/row.rs
+++ b/src/view/key_val/row.rs
@@ -126,10 +126,10 @@ impl Row {
         value_placeholder_text: impl Into<String>,
         entry: &model::KeyVal,
     ) -> Self {
-        glib::Object::builder::<Self>()
-            .property("key-val", &entry)
-            .property("key-placeholder-text", &key_placeholder_text.into())
-            .property("value-placeholder-text", &value_placeholder_text.into())
+        glib::Object::builder()
+            .property("key-val", entry)
+            .property("key-placeholder-text", key_placeholder_text.into())
+            .property("value-placeholder-text", value_placeholder_text.into())
             .build()
     }
     pub(crate) fn key_val(&self) -> Option<model::KeyVal> {

--- a/src/view/pod/creation_page.rs
+++ b/src/view/pod/creation_page.rs
@@ -279,9 +279,7 @@ glib::wrapper! {
 
 impl From<&model::Client> for CreationPage {
     fn from(client: &model::Client) -> Self {
-        glib::Object::builder::<Self>()
-            .property("client", client)
-            .build()
+        glib::Object::builder().property("client", client).build()
     }
 }
 
@@ -505,20 +503,24 @@ impl CreationPage {
     }
 
     fn search_image(&self) {
-        let image_selection_page = view::ImageSelectionPage::from(self.client().as_ref());
-        image_selection_page.connect_image_selected(clone!(@weak self as obj => move |_, image| {
-            let imp = obj.imp();
+        if let Some(client) = self.client() {
+            let image_selection_page = view::ImageSelectionPage::from(&client);
+            image_selection_page.connect_image_selected(
+                clone!(@weak self as obj => move |_, image| {
+                    let imp = obj.imp();
 
-            imp.infra_local_image_combo_row.set_visible(false);
-            imp.infra_remote_image_row.set_visible(true);
-            imp.infra_remote_image_row.set_subtitle(&image);
-            imp.infra_pull_latest_image_row.set_visible(false);
+                    imp.infra_local_image_combo_row.set_visible(false);
+                    imp.infra_remote_image_row.set_visible(true);
+                    imp.infra_remote_image_row.set_subtitle(&image);
+                    imp.infra_pull_latest_image_row.set_visible(false);
 
-            imp.infra_command_entry_row.set_text("");
-        }));
-        self.imp()
-            .leaflet_overlay
-            .show_details(&image_selection_page);
+                    imp.infra_command_entry_row.set_text("");
+                }),
+            );
+            self.imp()
+                .leaflet_overlay
+                .show_details(&image_selection_page);
+        }
     }
 
     fn update_infra_command_row(&self) {

--- a/src/view/pod/details_page.rs
+++ b/src/view/pod/details_page.rs
@@ -234,7 +234,7 @@ glib::wrapper! {
 
 impl From<&model::Pod> for DetailsPage {
     fn from(pod: &model::Pod) -> Self {
-        glib::Object::builder::<Self>().property("pod", pod).build()
+        glib::Object::builder().property("pod", pod).build()
     }
 }
 

--- a/src/view/pod/row.rs
+++ b/src/view/pod/row.rs
@@ -163,7 +163,7 @@ glib::wrapper! {
 
 impl From<&model::Pod> for Row {
     fn from(pod: &model::Pod) -> Self {
-        glib::Object::builder::<Self>().property("pod", pod).build()
+        glib::Object::builder().property("pod", pod).build()
     }
 }
 

--- a/src/view/pods/panel.rs
+++ b/src/view/pods/panel.rs
@@ -265,7 +265,7 @@ glib::wrapper! {
 
 impl Default for Panel {
     fn default() -> Self {
-        glib::Object::builder::<Self>().build()
+        glib::Object::builder().build()
     }
 }
 

--- a/src/view/port_mapping/row.rs
+++ b/src/view/port_mapping/row.rs
@@ -86,8 +86,8 @@ glib::wrapper! {
 
 impl From<&model::PortMapping> for Row {
     fn from(port_mapping: &model::PortMapping) -> Self {
-        glib::Object::builder::<Self>()
-            .property("port-mapping", &port_mapping)
+        glib::Object::builder()
+            .property("port-mapping", port_mapping)
             .build()
     }
 }

--- a/src/view/repo_tag/add_dialog.rs
+++ b/src/view/repo_tag/add_dialog.rs
@@ -163,7 +163,7 @@ glib::wrapper! {
 
 impl From<&model::Image> for AddDialog {
     fn from(image: &model::Image) -> Self {
-        let obj = glib::Object::builder::<Self>().build();
+        let obj: Self = glib::Object::builder().build();
         obj.imp().image.set(Some(image));
         obj
     }

--- a/src/view/repo_tag/row.rs
+++ b/src/view/repo_tag/row.rs
@@ -107,7 +107,7 @@ glib::wrapper! {
 
 impl From<&model::RepoTag> for Row {
     fn from(repo_tag: &model::RepoTag) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("repo-tag", repo_tag)
             .build()
     }

--- a/src/view/repo_tag/simple_row.rs
+++ b/src/view/repo_tag/simple_row.rs
@@ -88,7 +88,7 @@ glib::wrapper! {
 
 impl From<&model::RepoTag> for SimpleRow {
     fn from(repo_tag: &model::RepoTag) -> Self {
-        glib::Object::builder::<Self>()
+        glib::Object::builder()
             .property("repo-tag", repo_tag)
             .build()
     }

--- a/src/view/value/row.rs
+++ b/src/view/value/row.rs
@@ -87,9 +87,9 @@ impl From<&model::Value> for Row {
 
 impl Row {
     pub fn new(value: &model::Value, title: impl Into<String>) -> Self {
-        glib::Object::builder::<Self>()
-            .property("value", &value)
-            .property("title", &title.into())
+        glib::Object::builder()
+            .property("value", value)
+            .property("title", title.into())
             .build()
     }
 

--- a/src/view/volume/row.rs
+++ b/src/view/volume/row.rs
@@ -84,9 +84,7 @@ glib::wrapper! {
 
 impl From<&model::Volume> for Row {
     fn from(volume: &model::Volume) -> Self {
-        glib::Object::builder::<Self>()
-            .property("volume", &volume)
-            .build()
+        glib::Object::builder().property("volume", volume).build()
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -440,9 +440,7 @@ glib::wrapper! {
 
 impl Window {
     pub(crate) fn new(app: &Application) -> Self {
-        glib::Object::builder::<Self>()
-            .property("application", app)
-            .build()
+        glib::Object::builder().property("application", app).build()
     }
 
     fn save_window_size(&self) -> Result<(), glib::BoolError> {
@@ -846,9 +844,11 @@ impl Window {
     }
 
     fn show_podman_info_dialog(&self) {
-        let dialog = view::InfoDialog::from(self.connection_manager().client().as_ref());
-        dialog.set_transient_for(Some(self));
-        dialog.present();
+        if let Some(client) = self.connection_manager().client() {
+            let dialog = view::InfoDialog::from(&client);
+            dialog.set_transient_for(Some(self));
+            dialog.present();
+        }
     }
 
     fn toggle_search(&self) {


### PR DESCRIPTION
Use `From<T>` instead of `From<Option<T>>` and omit `&` for properties
where it is possible.