### PR TITLE
chore(app-data): Use tilde as beta separator

### DIFF
--- a/data/com.github.marhkb.Pods.metainfo.xml.in.in
+++ b/data/com.github.marhkb.Pods.metainfo.xml.in.in
@@ -42,7 +42,7 @@
   <url type="bugtracker">https://github.com/marhkb/pods/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.1.0-beta.4" date="2023-03-03">
+    <release version="1.1.0~beta.4" date="2023-03-03">
       <description>
         <p>Pods 1.1.0-beta.4 contains the following features, bug fixes and improvements:</p>
         <ul>
@@ -62,7 +62,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.1.0-beta.3" date="2023-02-05">
+    <release version="1.1.0~beta.3" date="2023-02-05">
       <description>
         <p>Pods 1.1.0-beta.3 contains the following features, bug fixes and improvements:</p>
         <ul>
@@ -80,7 +80,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.1.0-beta.2" date="2023-02-01">
+    <release version="1.1.0~beta.2" date="2023-02-01">
       <description>
         <p>Pods 1.1.0-beta.2 contains the following features, bug fixes and improvements:</p>
         <ul>
@@ -96,7 +96,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.1.0-beta.1" date="2023-01-28">
+    <release version="1.1.0~beta.1" date="2023-01-28">
       <description>
         <p>Pods 1.1.0-beta.1 contains the following features, bug fixes and improvements:</p>
         <ul>


### PR DESCRIPTION
A dash won't allow us to set a 1.1.0 release.