### PR TITLE
refactor(container-log-page): Replace InfoBar with Banner

### DIFF
--- a/data/resources/ui/container/log-page.ui
+++ b/data/resources/ui/container/log-page.ui
@@ -215,24 +215,10 @@
     </child>
 
     <child>
-      <object class="GtkInfoBar" id="info_bar">
-
-        <child>
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Streaming is disconnected because container isn't running.</property>
-            <property name="margin-start">6</property>
-            <property name="wrap">True</property>
-            <property name="wrap-mode">word-char</property>
-          </object>
-        </child>
-
-        <child type="action">
-          <object class="GtkButton">
-            <property name="action-name">container-log-page.start-container</property>
-            <property name="label" translatable="yes">Start/Resume Container</property>
-          </object>
-        </child>
-
+      <object class="AdwBanner" id="banner">
+        <property name="action-name">container-log-page.start-container</property>
+        <property name="button-label" translatable="yes">Start/Resume Container.</property>
+        <property name="title" translatable="yes">Streaming is disconnected because container isn't running.</property>
       </object>
     </child>
 

--- a/src/view/container/log_page.rs
+++ b/src/view/container/log_page.rs
@@ -87,7 +87,7 @@ mod imp {
         #[template_child]
         pub(super) source_buffer: TemplateChild<sourceview5::Buffer>,
         #[template_child]
-        pub(super) info_bar: TemplateChild<gtk::InfoBar>,
+        pub(super) banner: TemplateChild<adw::Banner>,
     }
 
     #[glib::object_subclass]
@@ -344,7 +344,7 @@ mod imp {
                 .chain_closure::<bool>(closure!(|_: Self::Type, status: model::ContainerStatus| {
                     status != model::ContainerStatus::Running
                 }))
-                .bind(&*self.info_bar, "revealed", Some(obj));
+                .bind(&*self.banner, "revealed", Some(obj));
 
             if let Some(container) = obj.container() {
                 container.connect_notify_local(


### PR DESCRIPTION
Since libadwaita 1.3 there is `AdwBanner` that should be used instead of `GtkInfoBar`.