### PR TITLE
fix(SearchPanel): Use to_lowercase for id and repo tag search

### DIFF
--- a/src/model/repo_tag_list.rs
+++ b/src/model/repo_tag_list.rs
@@ -96,12 +96,12 @@ impl RepoTagList {
             .map(|(_, c)| c.clone())
     }
 
-    pub(crate) fn contains(&self, uppercase_term: &str) -> bool {
+    pub(crate) fn contains(&self, lowercase_term: &str) -> bool {
         self.imp()
             .list
             .borrow()
             .keys()
-            .any(|full| full.to_uppercase().contains(uppercase_term))
+            .any(|full| full.contains(lowercase_term))
     }
 
     pub(crate) fn add(&self, repo_tag: model::RepoTag) {

--- a/src/view/search_panel.rs
+++ b/src/view/search_panel.rs
@@ -80,22 +80,21 @@ mod imp {
 
             let filter =
                 gtk::CustomFilter::new(clone!(@weak obj => @default-return false, move |item| {
-                    let term = obj.term().to_uppercase();
+                    let term = obj.term().to_lowercase();
 
                     if term.is_empty() {
                         false
                     } else if let Some(container) = item.downcast_ref::<model::Container>() {
                         container
-                            .name().to_uppercase().contains(&term)
-                            || container
-                                .id().contains(&term)
+                            .name().to_lowercase().contains(&term)
+                            || container.id().contains(&term)
                             || container
                                 .image_name()
-                                .map(|image_name| image_name.to_uppercase().contains(&term))
+                                .map(|image_name| image_name.to_lowercase().contains(&term))
                                 .unwrap_or(false)
                             || container.image_id().contains(&term)
                     } else if let Some(pod) = item.downcast_ref::<model::Pod>() {
-                        pod.name().to_uppercase().contains(&term)
+                        pod.name().to_lowercase().contains(&term)
                     } else if let Some(image) = item.downcast_ref::<model::Image>() {
                         image.id().contains(&term) || image.repo_tags().contains(&term)
                     } else {
@@ -257,9 +256,9 @@ impl SearchPanel {
         );
 
         imp.main_stack.set_visible_child_name(
-            if imp.images_group.is_visible()
-                || imp.containers_group.is_visible()
+            if imp.containers_group.is_visible()
                 || imp.pods_group.is_visible()
+                || imp.images_group.is_visible()
             {
                 "results"
             } else if self.term().is_empty() {


### PR DESCRIPTION
fix(SearchPanel): Use to_lowercase for id and repo tag search

We used to use `to_uppercase` for this. But this will not match ids in
most cases. In addition, we don't need to convert repo tags to uppercase
because they are always lowercase.