### PR TITLE
fix(window): Use correct actions to create entities

### DIFF
--- a/src/view/containers/panel.rs
+++ b/src/view/containers/panel.rs
@@ -209,6 +209,10 @@ impl Default for Panel {
 }
 
 impl Panel {
+    pub(crate) fn action_create_container() -> &'static str {
+        view::ContainersGroup::action_create_container()
+    }
+
     pub(crate) fn create_container(&self) {
         if let Some(client) = self
             .container_list()

--- a/src/view/images/panel.rs
+++ b/src/view/images/panel.rs
@@ -19,7 +19,7 @@ use crate::model::SelectableListExt;
 use crate::utils;
 use crate::view;
 
-const ACTION_PULL_IMAGE: &str = "images-panel.pull-image";
+pub(crate) const ACTION_PULL_IMAGE: &str = "images-panel.pull-image";
 const ACTION_BUILD_IMAGE: &str = "images-panel.build-image";
 const ACTION_PRUNE_UNUSED_IMAGES: &str = "images-panel.prune-unused-images";
 const ACTION_SHOW_ADD_IMAGE_MENU: &str = "images-panel.show-add-image-menu";
@@ -320,6 +320,10 @@ impl Default for Panel {
 }
 
 impl Panel {
+    pub(crate) fn action_pull_image() -> &'static str {
+        ACTION_PULL_IMAGE
+    }
+
     pub(crate) fn update_properties_filter(&self, filter_change: gtk::FilterChange) {
         self.imp()
             .properties_filter

--- a/src/view/pods/panel.rs
+++ b/src/view/pods/panel.rs
@@ -316,6 +316,10 @@ impl Default for Panel {
 }
 
 impl Panel {
+    pub(crate) fn action_create_pod() -> &'static str {
+        ACTION_CREATE_POD
+    }
+
     pub(crate) fn update_properties_filter(&self, filter_change: gtk::FilterChange) {
         self.imp()
             .properties_filter

--- a/src/window.rs
+++ b/src/window.rs
@@ -854,9 +854,13 @@ impl Window {
                 .map(|name| match name.as_str() {
                     "containers" => imp
                         .containers_panel
-                        .activate_action("containers.create", None),
-                    "pods" => imp.pods_panel.activate_action("pods.create", None),
-                    "images" => imp.images_panel.activate_action("images.pull", None),
+                        .activate_action(view::ContainersPanel::action_create_container(), None),
+                    "pods" => imp
+                        .pods_panel
+                        .activate_action(view::PodsPanel::action_create_pod(), None),
+                    "images" => imp
+                        .images_panel
+                        .activate_action(view::ImagesPanel::action_pull_image(), None),
                     _ => unreachable!(),
                 });
         }


### PR DESCRIPTION
This was a regression causing `Ctrl+N` to be without effect.