### PR TITLE
style(image-row): Center content

### DIFF
--- a/data/resources/ui/image/row.ui
+++ b/data/resources/ui/image/row.ui
@@ -5,9 +5,9 @@
 
     <child>
       <object class="GtkBox">
-        <property name="margin-top">7</property>
+        <property name="margin-top">8</property>
         <property name="margin-end">12</property>
-        <property name="margin-bottom">9</property>
+        <property name="margin-bottom">8</property>
         <property name="margin-start">12</property>
 
         <child>


### PR DESCRIPTION
The content of the image row wasn't vertically aligned in a way that it
complies to container and pod rows. This regression was probably
introduced in libadwaita 1.3.