### PR TITLE
fix(widget): Provide fallbacks for lookup colors

### DIFF
--- a/src/view/component/circular_progress_bar.rs
+++ b/src/view/component/circular_progress_bar.rs
@@ -129,18 +129,45 @@ mod imp {
                 percentage = 0.0;
             }
 
-            let fg_color = style_context
-                .lookup_color(if percentage < 0.8 {
-                    "accent_color"
-                } else if percentage < 0.95 {
-                    "warning_color"
-                } else {
-                    "error_color"
-                })
-                .unwrap();
+            let fg_color = if percentage < 0.8 {
+                style_context
+                    .lookup_color("accent_color")
+                    .unwrap_or_else(|| {
+                        if style_manager.is_dark() {
+                            gdk::RGBA::new(0.471, 0.682, 0.929, 1.0)
+                        } else {
+                            gdk::RGBA::new(0.11, 0.443, 0.847, 1.0)
+                        }
+                    })
+            } else if percentage < 0.95 {
+                style_context
+                    .lookup_color("warning_color")
+                    .unwrap_or_else(|| {
+                        if style_manager.is_dark() {
+                            gdk::RGBA::new(0.973, 0.894, 0.361, 1.0)
+                        } else {
+                            gdk::RGBA::new(0.612, 0.431, 0.012, 1.0)
+                        }
+                    })
+            } else {
+                style_context
+                    .lookup_color("error_color")
+                    .unwrap_or_else(|| {
+                        if style_manager.is_dark() {
+                            gdk::RGBA::new(1.0, 0.482, 0.388, 1.0)
+                        } else {
+                            gdk::RGBA::new(0.753, 0.11, 0.157, 1.0)
+                        }
+                    })
+            };
 
             let (bg_color, maybe_compiled_masked_shader) = if style_manager.is_high_contrast() {
-                (style_context.lookup_color("dark_1").unwrap(), None)
+                (
+                    style_context
+                        .lookup_color("dark_1")
+                        .unwrap_or_else(|| gdk::RGBA::new(0.467, 0.463, 0.482, 1.0)),
+                    None,
+                )
             } else {
                 let maybe_compiled_masked_shader = widget.ensure_mask_shader();
 
@@ -161,11 +188,21 @@ mod imp {
                                 },
                             )
                         })
-                        .unwrap()
+                        .unwrap_or_else(|| {
+                            if style_manager.is_dark() {
+                                gdk::RGBA::new(1.0, 1.0, 1.0, 0.15)
+                            } else {
+                                gdk::RGBA::new(0.0, 0.0, 0.0, 0.12)
+                            }
+                        })
                 } else if style_manager.is_dark() {
-                    style_context.lookup_color("dark_2").unwrap()
+                    style_context
+                        .lookup_color("dark_2")
+                        .unwrap_or_else(|| gdk::RGBA::new(0.369, 0.361, 0.392, 1.0))
                 } else {
-                    style_context.lookup_color("light_3").unwrap()
+                    style_context
+                        .lookup_color("light_3")
+                        .unwrap_or_else(|| gdk::RGBA::new(0.871, 0.867, 0.855, 1.0))
                 };
 
                 (color, maybe_compiled_masked_shader)

--- a/src/view/component/spinner.rs
+++ b/src/view/component/spinner.rs
@@ -223,7 +223,15 @@ mod imp {
             } else {
                 snapshot.push_rounded_clip(&gsk::RoundedRect::from_rect(rect, size / 2.0));
                 snapshot.append_color(
-                    &style_context.lookup_color("dialog_bg_color").unwrap(),
+                    &style_context
+                        .lookup_color("dialog_bg_color")
+                        .unwrap_or_else(|| {
+                            if adw::StyleManager::default().is_dark() {
+                                gdk::RGBA::new(0.22, 0.22, 0.22, 1.0)
+                            } else {
+                                gdk::RGBA::new(0.98, 0.98, 0.98, 1.0)
+                            }
+                        }),
                     &rect,
                 );
                 snapshot.pop();

--- a/src/view/container/tty.rs
+++ b/src/view/container/tty.rs
@@ -431,8 +431,24 @@ impl Tty {
         let style_context = self.style_context();
 
         let terminal = &*self.imp().terminal;
-        terminal.set_color_background(&style_context.lookup_color("view_bg_color").unwrap());
-        terminal.set_color_foreground(&style_context.lookup_color("view_fg_color").unwrap());
+        terminal.set_color_background(&style_context.lookup_color("view_bg_color").unwrap_or_else(
+            || {
+                if adw::StyleManager::default().is_dark() {
+                    gdk::RGBA::new(0.118, 0.118, 0.118, 1.0)
+                } else {
+                    gdk::RGBA::new(1.0, 1.0, 1.0, 1.0)
+                }
+            },
+        ));
+        terminal.set_color_foreground(&style_context.lookup_color("view_fg_color").unwrap_or_else(
+            || {
+                if adw::StyleManager::default().is_dark() {
+                    gdk::RGBA::new(1.0, 1.0, 1.0, 1.0)
+                } else {
+                    gdk::RGBA::new(0.0, 0.0, 0.0, 0.8)
+                }
+            },
+        ));
     }
 
     pub(crate) fn zoom_out(&self) {


### PR DESCRIPTION
The user could set a custom theme lacking the requested colors. Although this will look broken and completely out of place, we still don't want the application to crash because it couldn't find a color.

Fixes #641