### PR TITLE
fix(container-terminal): Change `backspace-binding`

### DIFF
--- a/src/view/container_terminal.rs
+++ b/src/view/container_terminal.rs
@@ -220,7 +220,6 @@ mod imp {
                     obj.update_copy_actions();
                 }));
 
-            self.terminal.set_bold_is_bright(true);
             self.terminal.set_colors(
                 None,
                 None,

--- a/src/view/container_terminal.ui
+++ b/src/view/container_terminal.ui
@@ -60,6 +60,7 @@
 
             <property name="child">
               <object class="VteTerminal" id="terminal">
+                <property name="bold-is-bright">True</property>
                 <property name="vexpand">True</property>
 
                 <child>

--- a/src/view/container_terminal.ui
+++ b/src/view/container_terminal.ui
@@ -60,6 +60,7 @@
 
             <property name="child">
               <object class="VteTerminal" id="terminal">
+                <property name="backspace-binding">ascii-delete</property>
                 <property name="bold-is-bright">True</property>
                 <property name="vexpand">True</property>
 


### PR DESCRIPTION
Changing this property to the value `ascii-delete` should fix a bug
where pressing backspace would produce `^H` in some cases.

Fixes #705