### PR TITLE
fix(container-terminal): Close processes on exit

### DIFF
--- a/data/com.github.marhkb.Pods.metainfo.xml.in.in
+++ b/data/com.github.marhkb.Pods.metainfo.xml.in.in
@@ -47,6 +47,7 @@
         <p>Pods 2.1.0 contains the following changes:</p>
         <ul>
           <li>Build about dialog from appdata. (#743)</li>
+          <li>Close all remaining processes after container terminal exits. (#744)</li>
         </ul>
       </description>
     </release>

--- a/src/view/container_terminal_page.rs
+++ b/src/view/container_terminal_page.rs
@@ -165,6 +165,8 @@ impl From<&model::Container> for ContainerTerminalPage {
 impl ContainerTerminalPage {
     pub(crate) fn pip_out(&self) {
         if let Some(navigation_view) = utils::try_navigation_view(self.upcast_ref()) {
+            self.imp().terminal.keep_alive_on_next_unroot();
+
             self.action_set_enabled(ACTION_PIP_OUT, false);
 
             let animate_transitions = navigation_view.is_animate_transitions();


### PR DESCRIPTION
I remember this used to work, but it must have regressed somehow.