### PR TITLE
fix(utils): Stop stream on glib::ControlFlow::Break

### DIFF
--- a/data/com.github.marhkb.Pods.metainfo.xml.in.in
+++ b/data/com.github.marhkb.Pods.metainfo.xml.in.in
@@ -60,6 +60,7 @@
         <p>Fixes</p>
         <ul>
           <li>All remaining processes are now closed after a container terminal exits. (#744)</li>
+          <li>Streams are now closed correctly so that they do not run forever when the user changes the connection. (#764)</li>
         </ul>
         <p>Improvements</p>
         <ul>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -367,7 +367,9 @@ pub(crate) fn run_stream_with_finish_handler<A, P, I, F, X>(
 
     glib::spawn_future_local(async move {
         while let Some(i) = rx_payload.recv().await {
-            glib_closure(i);
+            if glib_closure(i) == glib::ControlFlow::Break {
+                break;
+            }
         }
         finish_handler();
     });


### PR DESCRIPTION
Otherwise, streams run forever when we change the connection.