### PR TITLE
Style/actions/reduce-colors

### DIFF
--- a/data/com.github.marhkb.Pods.metainfo.xml.in.in
+++ b/data/com.github.marhkb.Pods.metainfo.xml.in.in
@@ -47,7 +47,7 @@
         <p>Pods 2.1.0 contains the following changes:</p>
         <p>Features</p>
         <ul>
-          <li>Accent colors are now properly supported. (#804)</li>
+          <li>Accent colors are now properly supported. (#804, #807)</li>
           <li>Containers are now represented by cards in the container panel. (#778)</li>
           <li>
             The image search has been completely revised and is now much more streamlined.

--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -2,6 +2,11 @@ containercard separator {
 	background-color: var(--window-bg-color);
 }
 
+actionsbutton.finished .action-count-badge {
+  background-color: var(--light-3);
+  color: var(--dark-5);
+}
+
 .version,
 .container-health-status-not-running,
 .container-status-not-running,

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -62,24 +62,18 @@ actionsbutton .action-count-badge {
   padding: 6px;
 }
 
-actionsbutton.good .action-count-badge {
+actionsbutton.ongoing .action-count-badge {
   background-color: var(--accent-bg-color);
-  color: var(--accent_fg-color);
+  color: var(--accent-fg-color);
 }
 
 actionsbutton.finished .action-count-badge {
-  background-color: var(--success-bg-color);
-  color: var(--success_fg-color);
+  background-color: var(--dark-3);
+  color: var(--light-1);
 }
 
-actionsbutton.aborted .action-count-badge {
-  background-color: var(--warning-bg-color);
-  color: var(--warning_fg-color);
-}
-
-actionsbutton.failed .action-count-badge {
-  background-color: var(--error-bg-color);
-  color: var(--error_fg-color);
+actionsbutton.failed .image-button {
+  color: var(--error-color);
 }
 
 connectionrow #selection-indicator #background,

--- a/src/view/action_row.rs
+++ b/src/view/action_row.rs
@@ -113,7 +113,7 @@ mod imp {
                             .cloned()
                             .chain(Some(String::from(match state {
                                 Ongoing => "accent",
-                                Finished => "success",
+                                Finished => "dim-label",
                                 Aborted => "warning",
                                 Failed => "error",
                             })))

--- a/src/view/actions_button.rs
+++ b/src/view/actions_button.rs
@@ -88,21 +88,18 @@ mod imp {
 
             gtk::ClosureExpression::new::<Vec<String>>(
                 &[
-                    action_list_expr.chain_property::<model::ActionList>("failed"),
-                    action_list_expr.chain_property::<model::ActionList>("aborted"),
                     action_list_expr.chain_property::<model::ActionList>("ongoing"),
+                    action_list_expr.chain_property::<model::ActionList>("failed"),
                 ],
-                closure!(|_: Self::Type, failed: u32, aborted: u32, ongoing: u32| {
-                    vec![if failed > 0 {
-                        "failed"
-                    } else if aborted > 0 {
-                        "aborted"
-                    } else if ongoing > 0 {
-                        "good"
-                    } else {
-                        "finished"
-                    }
-                    .to_string()]
+                closure!(|_: Self::Type, ongoing: u32, failed: u32| {
+                    Some(if ongoing > 0 { "ongoing" } else { "finished" }.to_string())
+                        .into_iter()
+                        .chain(if failed > 0 {
+                            Some(String::from("failed"))
+                        } else {
+                            None
+                        })
+                        .collect::<Vec<_>>()
                 }),
             )
             .bind(obj, "css-classes", Some(obj));


### PR DESCRIPTION
To reduce the strain on the eye, we ignore the canceled actions and
color the bell symbol instead of the badge.