### PR TITLE
fix:[#875] move output behind button

### DIFF
--- a/src/view/action_page.rs
+++ b/src/view/action_page.rs
@@ -14,6 +14,7 @@ use crate::utils;
 use crate::view;
 
 const ACTION_CANCEL: &str = "action-page.cancel";
+const ACTION_VIEW_OUTPUT: &str = "action-page.view-output";
 const ACTION_VIEW_ARTIFACT: &str = "action-page.view-artifact";
 const ACTION_RETRY: &str = "action-page.retry";
 
@@ -32,6 +33,8 @@ mod imp {
         pub(super) status_page: TemplateChild<adw::StatusPage>,
         #[template_child]
         pub(super) view_artifact_button: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub(super) output_box: TemplateChild<adw::Clamp>,
     }
 
     #[glib::object_subclass]
@@ -43,6 +46,9 @@ mod imp {
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
             klass.install_action(ACTION_CANCEL, None, |widget, _, _| widget.cancel());
+            klass.install_action(ACTION_VIEW_OUTPUT, None, |widget, _, _| {
+                widget.view_output()
+            });
             klass.install_action(ACTION_VIEW_ARTIFACT, None, |widget, _, _| {
                 widget.view_artifact();
             });
@@ -287,6 +293,14 @@ impl ActionPage {
         if let Some(action) = self.action() {
             action.cancel();
         }
+    }
+
+    fn view_output(&self) {
+        let imp = self.imp();
+        imp.status_page.set_icon_name(None);
+        imp.status_page.set_description(None);
+        imp.output_box.set_visible(true);
+        self.action_set_enabled(ACTION_VIEW_OUTPUT, false);
     }
 
     fn view_artifact(&self) {

--- a/src/view/action_page.ui
+++ b/src/view/action_page.ui
@@ -5,6 +5,7 @@
     <property name="mode">horizontal</property>
     <widgets>
       <widget name="abort_button"/>
+      <widget name="view_output_button"/>
       <widget name="view_artifact_button"/>
     </widgets>
   </object>
@@ -40,10 +41,14 @@
                 <child>
                   <object class="AdwClamp">
                     <property name="margin-bottom">9</property>
+                    <property name="orientation">vertical</property>
 
                     <child>
-                      <object class="AdwClamp">
+                      <object class="AdwClamp" id="output_box">
                         <property name="orientation">vertical</property>
+                        <property name="height-request">220</property>
+                        <property name="visible">False</property>
+
 
                         <property name="child">
                           <object class="AdwBin">
@@ -89,6 +94,21 @@
                       </object>
                     </child>
 
+                  </object>
+                </child>
+
+                <child>
+                  <object class="GtkButton" id="view_output_button">
+                    <style>
+                      <class name="pill"/>
+                    </style>
+                    <property name="action-name">action-page.view-output</property>
+                    <property name="halign">center</property>
+                    <property name="label" translatable="yes">_View Output</property>
+                    <property name="use-underline">True</property>
+                    <property name="visible" bind-source="view_output_button" bind-property="sensitive" bind-flags="sync-create"/>
+                    <property name="width-request">200</property>
+                    <property name="visible">True</property>
                   </object>
                 </child>
 


### PR DESCRIPTION
The PR hides the output of the command until the user presses, "view output".  this allows a cleaner interface and also enables the action pop up to have a dedicated view for the output so that the viewbox can be bigger.  here are some sample screen shots:

![Screenshot From 2025-03-23 19-07-39](https://github.com/user-attachments/assets/0f7aeccc-a970-4fc1-b024-245275af9f59)
![Screenshot From 2025-03-23 19-07-47](https://github.com/user-attachments/assets/8121550f-d6a5-4408-a5ff-57bc5113bb2f)
![Screenshot From 2025-03-23 19-07-00](https://github.com/user-attachments/assets/f1528d3c-dc5c-4e8a-95a4-05df856b6de3)
![Screenshot From 2025-03-23 19-07-05](https://github.com/user-attachments/assets/0e1a1f60-0949-462b-8de3-dc369410ba35)


closes #875 