### PR TITLE
fix: prevent unreachable state caused by unmatched label

### DIFF
--- a/src/view/action_page.rs
+++ b/src/view/action_page.rs
@@ -193,7 +193,7 @@ impl ActionPage {
                         CreateAndRunContainer => gettext("View Container"),
                         Pod => gettext("View Pod"),
                         Volume => gettext("View Volume"),
-                        _ => unreachable!(),
+                        _ => gettext("View"),
                     });
             }
             Aborted => {


### PR DESCRIPTION
this fixes the issue i created by accidentally making the label change default to an unreachable state :)