### PR TITLE
fix(widget/suggestion-entry-row): don't implement GtkEditable

### DIFF
--- a/src/widget/suggestion_entry_row.rs
+++ b/src/widget/suggestion_entry_row.rs
@@ -111,7 +111,6 @@ mod imp {
         const NAME: &'static str = "PdsSuggestionEntryRow";
         type Type = super::SuggestionEntryRow;
         type ParentType = adw::EntryRow;
-        type Interfaces = (gtk::Editable,);
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
@@ -170,7 +169,6 @@ mod imp {
     impl ListBoxRowImpl for SuggestionEntryRow {}
     impl PreferencesRowImpl for SuggestionEntryRow {}
     impl EntryRowImpl for SuggestionEntryRow {}
-    impl EditableImpl for SuggestionEntryRow {}
 
     #[gtk::template_callbacks]
     impl SuggestionEntryRow {


### PR DESCRIPTION
This is already implemented by its parent, AdwEntryRow. Removing the duplicate impl fixes a crash on inspecting the widget.