### PR TITLE
fix: don't categorize Pods as a terminal emulator

### DIFF
--- a/data/com.github.marhkb.Pods.desktop.in.in
+++ b/data/com.github.marhkb.Pods.desktop.in.in
@@ -4,7 +4,7 @@ Comment=Manage your Podman containers
 Type=Application
 Exec=pods
 Terminal=false
-Categories=GNOME;GTK;Development;System;Office;Network;Monitor;TerminalEmulator;RemoteAccess;
+Categories=GNOME;GTK;Development;System;Office;Network;Monitor;RemoteAccess;
 Keywords=Gnome;GTK;libadwaita;Podman;Containerization;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@


### PR DESCRIPTION
Fix Pods' `.desktop` launcher that miscategorizes it as a terminal emulator. The miscategorization causes `xdg-terminal-exec` to be set to Pods, breaking all desktop launchers that require a terminal.

This addresses bug https://github.com/marhkb/pods/issues/937.