### PR TITLE
build(manifest): set library paths

### DIFF
--- a/build-aux/com.github.marhkb.Pods.Devel.json
+++ b/build-aux/com.github.marhkb.Pods.Devel.json
@@ -9,6 +9,7 @@
   ],
   "command": "pods",
   "finish-args": [
+    "--env=LD_LIBRARY_PATH=/app/lib:/app/lib64",
     "--socket=fallback-x11",
     "--socket=wayland",
     "--share=network",
@@ -22,6 +23,8 @@
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm21/bin",
     "env": {
+      "PKG_CONFIG_PATH": "/app/lib/pkgconfig:/app/lib64/pkgconfig",
+      "LD_LIBRARY_PATH": "/app/lib:/app/lib64",
       "CARGO_REGISTRIES_CRATES_IO_PROTOCOL": "sparse",
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
@@ -33,12 +36,10 @@
   },
   "cleanup": [
     "/include",
-    "/lib/pkgconfig",
     "/man",
     "/share/doc",
     "/share/gtk-doc",
     "/share/man",
-    "/share/pkgconfig",
     "*.la",
     "*.a"
   ],


### PR DESCRIPTION
It seems this is suddenly needed, for building and running inside the devcontainer.