### PR TITLE
feat(view/container-details-page): confirm container deletion

### DIFF
--- a/src/view/container.rs
+++ b/src/view/container.rs
@@ -130,6 +130,30 @@ where
     }
 }
 
+pub(crate) fn safe_remove<W>(widget: &W, container: Option<model::Container>)
+where
+    W: IsA<gtk::Widget> + Downgrade<Weak = glib::WeakRef<W>>,
+{
+    let dialog = adw::AlertDialog::builder()
+        .heading(gettext("Delete Container?"))
+        .body_use_markup(true)
+        .body(gettext(
+            "All settings and all changes made within the container will be irreversibly lost",
+        ))
+        .build();
+
+    dialog.add_responses(&[
+        ("cancel", &gettext("_Cancel")),
+        ("confirm", &gettext("_Confirm")),
+    ]);
+    dialog.set_default_response(Some("cancel"));
+    dialog.set_response_appearance("confirm", adw::ResponseAppearance::Destructive);
+
+    if glib::MainContext::default().block_on(dialog.choose_future(Some(widget))) == "confirm" {
+        remove(widget, container)
+    }
+}
+
 macro_rules! container_action {
     (fn $name:ident => $action:ident($($param:literal),*) => $error:tt) => {
         pub(crate) fn $name<W>(widget: &W, container: Option<crate::model::Container>)

--- a/src/view/container_card.rs
+++ b/src/view/container_card.rs
@@ -564,24 +564,7 @@ impl ContainerCard {
     }
 
     pub(crate) fn delete(&self) {
-        let dialog = adw::AlertDialog::builder()
-            .heading(gettext("Delete Container?"))
-            .body_use_markup(true)
-            .body(gettext(
-                "All settings and all changes made within the container will be irreversibly lost",
-            ))
-            .build();
-
-        dialog.add_responses(&[
-            ("cancel", &gettext("_Cancel")),
-            ("confirm", &gettext("_Confirm")),
-        ]);
-        dialog.set_default_response(Some("cancel"));
-        dialog.set_response_appearance("confirm", adw::ResponseAppearance::Destructive);
-
-        if glib::MainContext::default().block_on(dialog.choose_future(Some(self))) == "confirm" {
-            view::container::remove(self, self.container())
-        }
+        view::container::safe_remove(self, self.container())
     }
 
     fn bind_stats_fraction(&self, stats_expr: &gtk::Expression, progress_bar: &gtk::ProgressBar) {

--- a/src/view/container_details_page.rs
+++ b/src/view/container_details_page.rs
@@ -121,7 +121,7 @@ mod imp {
                 view::container::resume(widget, widget.container());
             });
             klass.install_action(ACTION_DELETE, None, |widget, _, _| {
-                view::container::remove(widget, widget.container());
+                view::container::safe_remove(widget, widget.container());
             });
             klass.install_action(ACTION_INSPECT, None, |widget, _, _| {
                 widget.show_inspection();


### PR DESCRIPTION
With this commit, we show a confirmation dialog before deleting a container. This prevents the user from accidentally deleting the container. This change catches up with the container row and container card, where we already show a deletion confirmation dialog.